### PR TITLE
Added special menu option for win32 to hide the console window

### DIFF
--- a/gui/qt/CEmu.pro
+++ b/gui/qt/CEmu.pro
@@ -99,7 +99,7 @@ SOURCES +=  utils.cpp \
     searchwidget.cpp
 
 linux|macx|ios: SOURCES += ../../core/os/os-linux.c
-win32: SOURCES += ../../core/os/os-win32.c
+win32: SOURCES += ../../core/os/os-win32.c win32-console.cpp
 
 HEADERS  +=  utils.h \
     mainwindow.h \

--- a/gui/qt/mainwindow.cpp
+++ b/gui/qt/mainwindow.cpp
@@ -147,7 +147,11 @@ MainWindow::MainWindow(QWidget *p) : QMainWindow(p), ui(new Ui::MainWindow) {
     connect(ui->actionCheckForUpdates, &QAction::triggered, this, [=](){ this->checkForUpdates(true); });
     connect(ui->actionAbout, &QAction::triggered, this, &MainWindow::showAbout);
     connect(ui->actionAboutQt, &QAction::triggered, qApp, &QApplication::aboutQt);
-
+    
+#ifdef _WIN32
+    installToggleConsole();
+#endif
+    
     // Other GUI actions
     connect(ui->buttonRunSetup, &QPushButton::clicked, this, &MainWindow::runSetup);
     connect(ui->scaleSlider, &QSlider::sliderMoved, this, &MainWindow::reprintScale);

--- a/gui/qt/mainwindow.h
+++ b/gui/qt/mainwindow.h
@@ -190,6 +190,12 @@ private:
     // Reset
     void reloadROM();
     void resetCalculator();
+    
+#ifdef _WIN32
+    // Win32 Console Toggle
+    void toggleConsole();
+    void installToggleConsole();
+#endif
 
     // Members
     QString getAddressString(bool &, QString);

--- a/gui/qt/win32-console.cpp
+++ b/gui/qt/win32-console.cpp
@@ -1,0 +1,43 @@
+#ifdef _WIN32
+#include <QtWidgets/QAction>
+#include <QtWidgets/QMessageBox>
+#include <windows.h>
+#include "mainwindow.h"
+#include "ui_mainwindow.h"
+
+QAction *actionToggleConsole;
+
+void MainWindow::toggleConsole() {
+    if (actionToggleConsole->isChecked()) {
+        // If the console is created from opening up the EXE in
+        // Explorer, the console will be completely destroyed once the
+        // console is hidden/freed. Therefore, we need to check for
+        // that, and create a new console if necessary. On the other
+        // hand, if we spawned this process from an existing console,
+        // AttachConsole will still work!
+        if (!AttachConsole(ATTACH_PARENT_PROCESS)) {
+            if (!AllocConsole()) {
+                QMessageBox::critical(this, "Error", "Unable to open console.");
+            }
+        }
+    } else {
+        if (!FreeConsole()) {
+            QMessageBox::critical(this, "Error", "Unable to close console. If you are running directly from a console, you may not be able to close it.");
+        }
+    }
+}
+
+void MainWindow::installToggleConsole() {
+    // Build menu option and add it!
+    actionToggleConsole = new QAction(this);
+    actionToggleConsole->setObjectName(QStringLiteral("actionToggleConsole"));
+    actionToggleConsole->setText(QApplication::translate("MainWindow", "Toggle Windows Console", 0));
+    actionToggleConsole->setCheckable(true);
+    actionToggleConsole->setChecked(true);
+    actionToggleConsole->setEnabled(true);
+    ui->menuHelp->addAction(actionToggleConsole);
+    
+    // Connect menu action to function
+    connect(actionToggleConsole, &QAction::triggered, this, &MainWindow::toggleConsole);
+}
+#endif


### PR DESCRIPTION
With newer builds of CEmu, a console window is shown alongside
CEmu for debugging purposes. Some people may not like this, due
to the additional clutter and the fact that if the console window
is closed, CEmu is closed as well.

This commit adds in a bit of a hack - if compiled on Windows (or
rather, for Windows), a special menu option will be added to hide
or show the console window. When selected, it will enable/disable
the console.

Note that when CEmu is spawned from an existing console, the
console will not be hidden. Instead, output will no longer appear
in the console. Re-enabling the console will restore the ability
for future output to be shown.