### PR TITLE
Add ability to save whether the console is hidden or not

### DIFF
--- a/gui/qt/mainwindow.cpp
+++ b/gui/qt/mainwindow.cpp
@@ -148,10 +148,6 @@ MainWindow::MainWindow(QWidget *p) : QMainWindow(p), ui(new Ui::MainWindow) {
     connect(ui->actionAbout, &QAction::triggered, this, &MainWindow::showAbout);
     connect(ui->actionAboutQt, &QAction::triggered, qApp, &QApplication::aboutQt);
     
-#ifdef _WIN32
-    installToggleConsole();
-#endif
-    
     // Other GUI actions
     connect(ui->buttonRunSetup, &QPushButton::clicked, this, &MainWindow::runSetup);
     connect(ui->scaleSlider, &QSlider::sliderMoved, this, &MainWindow::reprintScale);
@@ -225,6 +221,10 @@ MainWindow::MainWindow(QWidget *p) : QMainWindow(p), ui(new Ui::MainWindow) {
     debuggerOn = false;
 
     settings = new QSettings(QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + QStringLiteral("/CEmu/cemu_config.ini"), QSettings::IniFormat);
+
+#ifdef _WIN32
+    installToggleConsole();
+#endif
 
     changeThrottleMode(Qt::Checked);
     emu.rom = settings->value(QStringLiteral("romImage")).toString().toStdString();

--- a/gui/qt/win32-console.cpp
+++ b/gui/qt/win32-console.cpp
@@ -25,6 +25,8 @@ void MainWindow::toggleConsole() {
             QMessageBox::critical(this, "Error", "Unable to close console. If you are running directly from a console, you may not be able to close it.");
         }
     }
+    
+    settings->setValue(QStringLiteral("enableWin32Console"), actionToggleConsole->isChecked());
 }
 
 void MainWindow::installToggleConsole() {
@@ -39,5 +41,11 @@ void MainWindow::installToggleConsole() {
     
     // Connect menu action to function
     connect(actionToggleConsole, &QAction::triggered, this, &MainWindow::toggleConsole);
+    
+    // Check if we opted to not show a window
+    if (!settings->value(QStringLiteral("enableWin32Console"), true).toBool()) {
+        actionToggleConsole->setChecked(false);
+        toggleConsole();
+    }
 }
 #endif


### PR DESCRIPTION
Added configuration option in QSettings for whether the console is
hidden or not. This allows regular users to keep the console hidden
without having to manually hide it each time they open CEmu.