### PR TITLE
Fix MSVC building of tivarslib in CEmu

### DIFF
--- a/gui/qt/tivarslib/utils_tivarslib.cpp
+++ b/gui/qt/tivarslib/utils_tivarslib.cpp
@@ -9,6 +9,7 @@
 #include <sstream>
 #include <iomanip>
 #include <regex>
+#include <functional>
 
 using namespace std;
 

--- a/gui/qt/tivarslib/utils_tivarslib.cpp
+++ b/gui/qt/tivarslib/utils_tivarslib.cpp
@@ -9,7 +9,6 @@
 #include <sstream>
 #include <iomanip>
 #include <regex>
-#include <unistd.h>
 
 using namespace std;
 


### PR DESCRIPTION
MSVC build fails at the moment with tivarslib:
https://ci.appveyor.com/project/alberthdev/cemu/build/1.0.104
https://ci.appveyor.com/project/alberthdev/cemu/build/1.0.106

Specifically, `gui/qt/tivarslib/utils_tivarslib.cpp` breaks due to two issues:

 * `#include <unistd.h>` - POSIX-only header, not needed at all.
 * Missing `#include <functional>` - GCC implicitly includes this, MSVC does not!

I've verified that with the changes above, it still compiles with GCC and [fixes the issue with MSVC](https://ci.appveyor.com/project/alberthdev/cemu/build/1.0.107) - could someone verify that Clang is happy with it as well (especially on Mac)? ([Branch with fix](https://github.com/alberthdev/CEmu/tree/fix-msvc-tivarlibscpp))
