### PR TITLE
Fix MSVC designated inits + math constants

### DIFF
--- a/gui/qt/keypad/arrowkey.h
+++ b/gui/qt/keypad/arrowkey.h
@@ -1,6 +1,11 @@
 #ifndef ARROWKEY_H
 #define ARROWKEY_H
 
+/* Enable math constants on MSVC */
+#ifdef _MSC_VER
+#define _USE_MATH_DEFINES
+#endif
+
 #include "key.h"
 #include "keyconfig.h"
 

--- a/gui/qt/keypad/keypadwidget.cpp
+++ b/gui/qt/keypad/keypadwidget.cpp
@@ -120,20 +120,18 @@ void KeypadWidget::setType(bool is83, unsigned color_scheme) {
     font.setStretch(QFont::SemiCondensed);
 #endif
 
-    m_config = {
-          .labelFont = font,
-         .secondFont = font,
-          .alphaFont = font,
-        .secondColor = QColor::fromRgb(0x93c3f3),
-         .alphaColor = QColor::fromRgb(0xa0ca1e),
-         .graphColor = c_graph,
-           .numColor = c_num,
-         .otherColor = c_other,
-         .blackColor = QColor::fromRgb(0x222222),
-         .whiteColor = QColor::fromRgb(0xeeeeee),
-          .textColor = c_text,
-                .key = {1, 0}
-    };
+    m_config.labelFont   = font,
+    m_config.secondFont  = font,
+    m_config.alphaFont   = font,
+    m_config.secondColor = QColor::fromRgb(0x93c3f3),
+    m_config.alphaColor  = QColor::fromRgb(0xa0ca1e),
+    m_config.graphColor  = c_graph,
+    m_config.numColor    = c_num,
+    m_config.otherColor  = c_other,
+    m_config.blackColor  = QColor::fromRgb(0x222222),
+    m_config.whiteColor  = QColor::fromRgb(0xeeeeee),
+    m_config.textColor   = c_text,
+    m_config.key         = {1, 0};
 
     if (is83) {
 #ifndef _WIN32


### PR DESCRIPTION
Two things fixed that impact the MSVC builds:

 * **Replace designated inits with struct assignments in keypadwidget.cpp**
   
   MSVC does not support designated initializers in C++ mode, so the
   previous assignments are replaced with regular struct assignments to
   allow MSVC to compile the code correctly.

 * **Define _USE_MATH_DEFINES (MSVC) to fix math consts (arrowkey.h)**

   MSVC does not provide the math.h constants by default, whereas
   POSIX (Linux/Mac, GCC+Clang) does. However, according to
   https://msdn.microsoft.com/en-us/library/4hwaceh6.aspx, they can be
   turned on by defining `_USE_MATH_DEFINES` before loading math.h (or in
   this case, `cmath`).
   
   Therefore, they are placed at the top of `arrowkey.h`, first included in
   `arrowkey.cpp`, before any other includes take place. (This includes the
   `key.h` and `keyconfig.h` includes, which both contain Qt includes that
   include `math.h`/`cmath`. Including after these Qt includes have taken
   place will result in the definitions not loading.)
