### PR TITLE
Fix Windows DPI scaling with Qt autoscaling (fixes #89)

### DIFF
--- a/gui/qt/keypad/keypadwidget.cpp
+++ b/gui/qt/keypad/keypadwidget.cpp
@@ -107,9 +107,7 @@ void KeypadWidget::setType(bool is83, unsigned color_scheme) {
 
     font.setBold(true);
     font.setPixelSize(5);
-#ifdef _WIN32
-    font.setWeight(QFont::Black);
-#else
+#ifndef Q_OS_WIN
     font.setStretch(QFont::SemiCondensed);
 #endif
 
@@ -125,12 +123,6 @@ void KeypadWidget::setType(bool is83, unsigned color_scheme) {
     m_config.whiteColor  = QColor::fromRgb(0xeeeeee),
     m_config.textColor   = c_text,
     m_config.key         = {1, 0};
-
-    if (is83) {
-#ifndef _WIN32
-        m_config.secondFont.setStretch(QFont::Condensed);
-#endif
-    }
 
 #ifdef _MSC_VER
 /* Temporary hack... QStringLiteral mangles the UTF-8 string on MSVC for some reason */

--- a/gui/qt/keypad/keypadwidget.cpp
+++ b/gui/qt/keypad/keypadwidget.cpp
@@ -107,7 +107,9 @@ void KeypadWidget::setType(bool is83, unsigned color_scheme) {
 
     font.setBold(true);
     font.setPixelSize(5);
-#ifndef Q_OS_WIN
+#ifdef Q_OS_WIN
+    font.setWeight(QFont::Black);
+#else
     font.setStretch(QFont::SemiCondensed);
 #endif
 

--- a/gui/qt/keypad/keypadwidget.cpp
+++ b/gui/qt/keypad/keypadwidget.cpp
@@ -105,16 +105,11 @@ void KeypadWidget::setType(bool is83, unsigned color_scheme) {
         font.setFamily("Open Sans Bold");
     }
 
-#ifdef _WIN32
-    font.setWeight(QFont::Black);
-    qreal screenDPI  = QApplication::primaryScreen()->physicalDotsPerInch();
-    qreal RENDER_DPI = 96;
-
-    int pixelSize = (int)((qreal)7 * screenDPI / RENDER_DPI);
-    font.setPixelSize(pixelSize);
-#else
     font.setBold(true);
     font.setPixelSize(5);
+#ifdef _WIN32
+    font.setWeight(QFont::Black);
+#else
     font.setStretch(QFont::SemiCondensed);
 #endif
 

--- a/gui/qt/main.cpp
+++ b/gui/qt/main.cpp
@@ -2,7 +2,7 @@
 #include "mainwindow.h"
 
 int main(int argc, char *argv[]) {
-#ifdef _WIN32
+#ifdef Q_OS_WIN
     // DPI scaling fix must be applied at the very beginning before QApplication init
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif

--- a/gui/qt/main.cpp
+++ b/gui/qt/main.cpp
@@ -2,6 +2,11 @@
 #include "mainwindow.h"
 
 int main(int argc, char *argv[]) {
+#ifdef _WIN32
+    // DPI scaling fix must be applied at the very beginning before QApplication init
+    QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#endif
+
     QApplication app(argc, argv);
 
     // Setup QCommandParser with Our command line parameters
@@ -49,6 +54,7 @@ int main(int argc, char *argv[]) {
 
     QCoreApplication::setOrganizationName(QStringLiteral("cemu-dev"));
     QCoreApplication::setApplicationName(QStringLiteral("CEmu"));
+
     app.setAttribute(Qt::AA_UseHighDpiPixmaps);
 
     MainWindow EmuWin(opts);


### PR DESCRIPTION
This resolves issues with the keypad text size on Windows by enabling automatic Qt DPI handling. This replaces the manual DPI handling code from before.

Note that this automatic scaling is only enabled on Windows - other platforms perform perfectly fine with their current DPI handling.