### PR TITLE
Add gh-pages deployment of gh-pages-dev to Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ branches:
   only:
     - master
     - coverity_scan
+    - gh-pages-dev
 
 dist: trusty
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,11 @@ notifications:
     on_success: change
     on_failure: always
     skip_join: true
+
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
+  local_dir: html
+  on:
+    branch: gh-pages-dev


### PR DESCRIPTION
Add automation of page building via Travis-CI from gh-pages-dev (branch for updating the web page) to gh-pages (branch where actual pages/content are hosted).