### PR TITLE
Include missing `cstring` header in autotester.cpp

### DIFF
--- a/tests/autotester/autotester.cpp
+++ b/tests/autotester/autotester.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <string>
+#include <cstring>
 #include <vector>
 #include <fstream>
 #include <iostream>


### PR DESCRIPTION
`memcpy` is used but the relevant header wasn't included, causing the file not to compile:
```c
../../tests/autotester/autotester.cpp: In lambda function:
../../tests/autotester/autotester.cpp:180:25: error: ‘memcpy’ was not declared in this scope
  180 |                         memcpy(temp_buffer_dup, temp_buffer, param.size);
      |                         ^~~~~~
../../tests/autotester/autotester.cpp:28:1: note: ‘memcpy’ is defined in header ‘<cstring>’; did you forget to ‘#include <cstring>’?
   27 | #include "autotester.h"
  +++ |+#include <cstring>
   28 | 
make: *** [Makefile:1417: autotester.o] Error 1

```