### PR TITLE
Add vertical printing to Keypress History

### DIFF
--- a/gui/qt/keyhistorywidget.cpp
+++ b/gui/qt/keyhistorywidget.cpp
@@ -37,20 +37,9 @@ KeyHistoryWidget::KeyHistoryWidget(QWidget *parent, int size) : QWidget{parent} 
 KeyHistoryWidget::~KeyHistoryWidget() = default;
 
 void KeyHistoryWidget::add(const QString &entry) {
-    QString key = getText(entry);
     m_view->moveCursor(QTextCursor::End);
-    m_view->insertPlainText(key);
+    m_view->insertPlainText(entry + (m_chkBoxVertical->isChecked() ? "\n" : ""));
     m_view->moveCursor(QTextCursor::End);
-}
-
-QString KeyHistoryWidget::getText(const QString &entry){
-    QString output = "";
-    QString verticalOption = "";
-    if (m_chkBoxVertical->checkState() == Qt::CheckState::Checked) {
-        verticalOption = "\n";
-    }
-    output = verticalOption + entry;
-    return output;
 }
 
 void KeyHistoryWidget::setFontSize(int size) {

--- a/gui/qt/keyhistorywidget.cpp
+++ b/gui/qt/keyhistorywidget.cpp
@@ -12,6 +12,7 @@ KeyHistoryWidget::KeyHistoryWidget(QWidget *parent, int size) : QWidget{parent} 
     m_view = new QPlainTextEdit();
     m_size = new QSpinBox();
     m_spacer = new QSpacerItem(0, 0, QSizePolicy::Expanding, QSizePolicy::Preferred);
+    m_chkBoxVertical = new QCheckBox(tr("Print Vertically"));
 
     m_view->setReadOnly(true);
     m_view->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
@@ -20,6 +21,7 @@ KeyHistoryWidget::KeyHistoryWidget(QWidget *parent, int size) : QWidget{parent} 
     hlayout->addSpacerItem(m_spacer);
     hlayout->addWidget(m_label);
     hlayout->addWidget(m_size);
+    hlayout->addWidget(m_chkBoxVertical);
 
     QVBoxLayout *vlayout = new QVBoxLayout();
     vlayout->addWidget(m_view);
@@ -35,9 +37,20 @@ KeyHistoryWidget::KeyHistoryWidget(QWidget *parent, int size) : QWidget{parent} 
 KeyHistoryWidget::~KeyHistoryWidget() = default;
 
 void KeyHistoryWidget::add(const QString &entry) {
+    QString key = getText(entry);
     m_view->moveCursor(QTextCursor::End);
-    m_view->insertPlainText(entry);
+    m_view->insertPlainText(key);
     m_view->moveCursor(QTextCursor::End);
+}
+
+QString KeyHistoryWidget::getText(const QString &entry){
+    QString output = "";
+    QString verticalOption = "";
+    if (m_chkBoxVertical->checkState() == Qt::CheckState::Checked) {
+        verticalOption = "\n";
+    }
+    output = verticalOption + entry;
+    return output;
 }
 
 void KeyHistoryWidget::setFontSize(int size) {

--- a/gui/qt/keyhistorywidget.h
+++ b/gui/qt/keyhistorywidget.h
@@ -24,7 +24,6 @@ signals:
     void fontSizeChanged();
 
 private:
-    QString getText(const QString &entry);
     void setFontSize(int size);
 
     QLabel *m_label;

--- a/gui/qt/keyhistorywidget.h
+++ b/gui/qt/keyhistorywidget.h
@@ -7,6 +7,7 @@
 #include <QtWidgets/QSpacerItem>
 #include <QtWidgets/QLabel>
 #include <QtWidgets/QSpinBox>
+#include <QtWidgets/QCheckBox>
 
 class KeyHistoryWidget : public QWidget {
     Q_OBJECT
@@ -23,6 +24,7 @@ signals:
     void fontSizeChanged();
 
 private:
+    QString getText(const QString &entry);
     void setFontSize(int size);
 
     QLabel *m_label;
@@ -30,6 +32,7 @@ private:
     QSpacerItem *m_spacer;
     QPlainTextEdit *m_view;
     QPushButton *m_btnClear;
+    QCheckBox *m_chkBoxVertical;
 };
 
 #endif


### PR DESCRIPTION
I have found displaying the key presses history vertically is more readable for some. Although the window can already be made narrow, relying on word wrapping does not always successfully put each key press on a new line. 

Example: 
Press [(] then [)] then [window].
It is currently impossible to have the parenthesis on new lines without [window] being cut off.

This pull request simply adds a check box to the Keypress History window which allows the user to toggle whether they want future key presses to word wrap or get put on a new line. Currently the state of the check box is not preserved after CEmu is closed. I would like to make it persistent in the future.

_keyhistorywidget.cpp_ and _keyhistorywidget.h_ have been edited to add a newline character `"\n"` to the beginning of a key, just before it's printed to the Keypress history. 

Although _CEmu.pro_ and _CEmu.pro.qtds_ have been modified, they are specific to my build and can be omitted from this pull request.

This is my very first pull request. Please bear with me as I learn how to do these.