### PR TITLE
Add SmartPad support

### DIFF
--- a/gui/qt/keypad/keymap.cpp
+++ b/gui/qt/keypad/keymap.cpp
@@ -26,8 +26,7 @@
 // Alt+Ctrl+Win+Shift
 #define ACWS(code) { Qt::Key_##code, 0, 0, Qt::AltModifier | Qt::ControlModifier | Qt::MetaModifier | Qt::ShiftModifier, Qt::AltModifier | Qt::ControlModifier | Qt::MetaModifier | Qt::ShiftModifier, QStringLiteral(#code) }
 
-
-//This applies the final key to calc conversion
+//This applies the final key to calc conversion for the following macros
 #define HK(code, nativeCode, nativeMask, modifier, mask) { Qt::Key_##code, nativeCode, nativeMask, Qt::modifier##Modifier, Qt::mask##Modifier, QStringLiteral(#code) }
 // NoRMal ignores modifiers
 #define NRM(code) HK(code, 0, 0, No, No)
@@ -36,10 +35,8 @@
 //MODifiers supports checking a single modifier for being pressed (Shift, Shift) or not being pressed (No, Shift)
 #define MOD(code, modifier, mask) HK(code, 0, 0, modifier, mask)
 
-
-
 //Note:
-//{ <key> , <key2>}
+//{ <key> , <key2> , none}
 //This is an OR statement. Valid if <key> OR <key2> is pressed.
 
 static HostKey none = { Qt::Key(0), 0, 0, Qt::NoModifier, Qt::NoModifier, {} };
@@ -313,7 +310,7 @@ const KEYMAP(_84pce);
 // ------------
 #define KEY(key) smartpad_k##key
 
-static const HostKey KEY(enter)[] = { NRM(Enter), none };
+static const HostKey KEY(enter)[] = { NRM(Enter), NRM(Return), none };
 static const HostKey KEY(2nd)[]   = { CW(F6), none };
 static const HostKey KEY(alpha)[] = { CW(F7), none };
 static const HostKey KEY(sto)[]   = { ACW(F4), none };

--- a/gui/qt/keypad/keymap.cpp
+++ b/gui/qt/keypad/keymap.cpp
@@ -13,11 +13,34 @@
         KEY(enter), KEY(add), KEY(sub), KEY(mul), KEY(div), KEY(pow), KEY(clr), &none,          \
         KEY(down), KEY(left), KEY(right), KEY(up), &none, &none, &none, &none                   \
     }
+// Alt+Win
+#define AW(code) { Qt::Key_##code, 0, 0, Qt::AltModifier | Qt::MetaModifier, Qt::AltModifier | Qt::ControlModifier | Qt::MetaModifier | Qt::ShiftModifier, QStringLiteral(#code) }
+// Ctrl+Win
+#define CW(code) { Qt::Key_##code, 0, 0, Qt::ControlModifier | Qt::MetaModifier, Qt::AltModifier | Qt::ControlModifier | Qt::MetaModifier | Qt::ShiftModifier, QStringLiteral(#code) }
+// Alt+Ctrl+Win
+#define ACW(code) { Qt::Key_##code, 0, 0, Qt::AltModifier | Qt::ControlModifier | Qt::MetaModifier, Qt::AltModifier | Qt::ControlModifier | Qt::MetaModifier | Qt::ShiftModifier, QStringLiteral(#code) }
+// Alt+Win+Shift
+#define AWS(code) { Qt::Key_##code, 0, 0, Qt::AltModifier | Qt::MetaModifier | Qt::ShiftModifier, Qt::AltModifier | Qt::ControlModifier | Qt::MetaModifier | Qt::ShiftModifier, QStringLiteral(#code) }
+// Ctrl+Win+Shift
+#define CWS(code) { Qt::Key_##code, 0, 0, Qt::ControlModifier | Qt::MetaModifier | Qt::ShiftModifier, Qt::AltModifier | Qt::ControlModifier | Qt::MetaModifier | Qt::ShiftModifier, QStringLiteral(#code) }
+// Alt+Ctrl+Win+Shift
+#define ACWS(code) { Qt::Key_##code, 0, 0, Qt::AltModifier | Qt::ControlModifier | Qt::MetaModifier | Qt::ShiftModifier, Qt::AltModifier | Qt::ControlModifier | Qt::MetaModifier | Qt::ShiftModifier, QStringLiteral(#code) }
 
+
+//This applies the final key to calc conversion
 #define HK(code, nativeCode, nativeMask, modifier, mask) { Qt::Key_##code, nativeCode, nativeMask, Qt::modifier##Modifier, Qt::mask##Modifier, QStringLiteral(#code) }
+// NoRMal ignores modifiers
 #define NRM(code) HK(code, 0, 0, No, No)
+//NATive supports distinguishing what would otherwise be identical keys like left and right shift
 #define NAT(code, nativeCode, nativeMask) HK(code, nativeCode, nativeMask, No, No)
+//MODifiers supports checking a single modifier for being pressed (Shift, Shift) or not being pressed (No, Shift)
 #define MOD(code, modifier, mask) HK(code, 0, 0, modifier, mask)
+
+
+
+//Note:
+//{ <key> , <key2>}
+//This is an OR statement. Valid if <key> OR <key2> is pressed.
 
 static HostKey none = { Qt::Key(0), 0, 0, Qt::NoModifier, Qt::NoModifier, {} };
 
@@ -284,6 +307,75 @@ static const HostKey KEY(on)[] = { NRM(F12), none };
 const KEYMAP(_83pce);
 const KEYMAP(_84pce);
 #undef KEY
+
+// ------------
+// SmartPad section
+// ------------
+#define KEY(key) smartpad_k##key
+
+static const HostKey KEY(enter)[] = { NRM(Enter), none };
+static const HostKey KEY(2nd)[]   = { CW(F6), none };
+static const HostKey KEY(alpha)[] = { CW(F7), none };
+static const HostKey KEY(sto)[]   = { ACW(F4), none };
+static const HostKey KEY(clr)[]   = { CWS(F9), none };
+static const HostKey KEY(del)[]   = { ACWS(F4), none };
+
+static const HostKey KEY(math)[] = { CW(F8), none };
+static const HostKey KEY(apps)[] = { ACW(F8), none };
+static const HostKey KEY(prgm)[] = { ACWS(F6), none };
+static const HostKey KEY(vars)[] = { CWS(F2), none };
+static const HostKey KEY(stat)[] = { ACWS(F5), none };
+static const HostKey KEY(mode)[] = { ACW(F6), none };
+static const HostKey KEY(xton)[] = { ACW(F7), none };
+
+static const HostKey KEY(neg)[] = { CWS(F8), none };
+static const HostKey KEY(add)[] = { CW(Plus), none };
+static const HostKey KEY(sub)[] = { CW(Minus), none };
+static const HostKey KEY(mul)[] = { CW(Asterisk), none };
+static const HostKey KEY(div)[] = { CW(Slash), none };
+static const HostKey KEY(pow)[] = { CWS(F11), none };
+
+static const HostKey KEY(sq)[]  = { ACW(F1), none };
+static const HostKey KEY(inv)[] = { CW(F9), none };
+static const HostKey KEY(ln)[]  = { ACW(F3), none };
+static const HostKey KEY(log)[] = { ACW(F2), none };
+static const HostKey KEY(sin)[] = { ACW(F9), none };
+static const HostKey KEY(cos)[] = { ACWS(F7), none };
+static const HostKey KEY(tan)[] = { CWS(F3), none };
+
+static const HostKey KEY(down)[]  = { AWS(Down), none };
+static const HostKey KEY(left)[]  = { AWS(Left), none };
+static const HostKey KEY(right)[] = { AWS(Right), none };
+static const HostKey KEY(up)[]    = { AWS(Up), none };
+
+static const HostKey KEY(0)[] = { ACWS(F3), none };
+static const HostKey KEY(1)[] = { ACWS(F2), none };
+static const HostKey KEY(2)[] = { ACWS(F11), none };
+static const HostKey KEY(3)[] = { CWS(F7), none };
+static const HostKey KEY(4)[] = { ACWS(F1), none };
+static const HostKey KEY(5)[] = { ACWS(F10), none };
+static const HostKey KEY(6)[] = { CWS(F6), none };
+static const HostKey KEY(7)[] = { ACW(F11), none };
+static const HostKey KEY(8)[] = { ACWS(F9), none };
+static const HostKey KEY(9)[] = { CWS(F5), none };
+
+static const HostKey KEY(dot)[] ={ CWS(F1), none };
+static const HostKey KEY(comma)[] = { ACW(F10), none };
+static const HostKey KEY(lpar)[] = { ACWS(F8), none };
+static const HostKey KEY(rpar)[] = { CWS(F4), none };
+
+static const HostKey KEY(yequ)[] = { CW(F1) , none };
+static const HostKey KEY(wind)[] = { CW(F2) , none };
+static const HostKey KEY(zoom)[] = { CW(F3), none };
+static const HostKey KEY(trace)[] = { CW(T), none };
+static const HostKey KEY(graph)[] = { CW(F5), none };
+static const HostKey KEY(on)[] = { ACW(F5), none };
+
+const KEYMAP(_83pce);
+const KEYMAP(_84pce);
+#undef KEY
+
+
 
 // ----------------
 // custom section

--- a/gui/qt/keypad/keymap.h
+++ b/gui/qt/keypad/keymap.h
@@ -14,11 +14,13 @@ extern const HostKey *const cemu_keymap_83pce[8*8];
 extern const HostKey *const tilem_keymap_83pce[8*8];
 extern const HostKey *const wabbitemu_keymap_83pce[8*8];
 extern const HostKey *const jstified_keymap_83pce[8*8];
+extern const HostKey *const smartpad_keymap_83pce[8*8];
 
 extern const HostKey *const cemu_keymap_84pce[8*8];
 extern const HostKey *const tilem_keymap_84pce[8*8];
 extern const HostKey *const wabbitemu_keymap_84pce[8*8];
 extern const HostKey *const jstified_keymap_84pce[8*8];
+extern const HostKey *const smartpad_keymap_84pce[8*8];
 
 extern HostKey *const custom_keymap[8*8];
 

--- a/gui/qt/keypad/qtkeypadbridge.cpp
+++ b/gui/qt/keypad/qtkeypadbridge.cpp
@@ -39,6 +39,9 @@ bool QtKeypadBridge::setKeymap(KeymapMode map) {
         case KEYMAP_JSTIFIED:
             keymap = get_device_type() == TI84PCE ? jstified_keymap_84pce : jstified_keymap_83pce;
             break;
+        case KEYMAP_SMARTPAD:
+            keymap = get_device_type() == TI84PCE ? smartpad_keymap_84pce : smartpad_keymap_83pce;
+            break;
         case KEYMAP_CUSTOM:
             keymap = custom_keymap;
             break;

--- a/gui/qt/keypad/qtkeypadbridge.h
+++ b/gui/qt/keypad/qtkeypadbridge.h
@@ -21,6 +21,7 @@ public:
         KEYMAP_TILEM,
         KEYMAP_WABBITEMU,
         KEYMAP_JSTIFIED,
+        KEYMAP_SMARTPAD,
         KEYMAP_CUSTOM,
     } KeymapMode;
 

--- a/gui/qt/mainwindow.cpp
+++ b/gui/qt/mainwindow.cpp
@@ -420,6 +420,7 @@ MainWindow::MainWindow(CEmuOpts &cliOpts, QWidget *p) : QMainWindow(p), ui(new U
     connect(ui->radioTilEmKeys, &QRadioButton::clicked, this, &MainWindow::keymapChanged);
     connect(ui->radioWabbitemuKeys, &QRadioButton::clicked, this, &MainWindow::keymapChanged);
     connect(ui->radiojsTIfiedKeys, &QRadioButton::clicked, this, &MainWindow::keymapChanged);
+    connect(ui->radioSmartPadKeys, &QRadioButton::clicked, this, &MainWindow::keymapChanged);
     connect(ui->radioCustomKeys, &QRadioButton::clicked, this, &MainWindow::keymapCustomSelected);
 
     // keypad

--- a/gui/qt/mainwindow.h
+++ b/gui/qt/mainwindow.h
@@ -717,6 +717,7 @@ private:
     static const QString SETTING_KEYPAD_TILEM;
     static const QString SETTING_KEYPAD_WABBITEMU;
     static const QString SETTING_KEYPAD_JSTIFIED;
+    static const QString SETTING_KEYPAD_SMARTPAD;
     static const QString SETTING_KEYPAD_CUSTOM;
     static const QString SETTING_KEYPAD_CUSTOM_PATH;
 

--- a/gui/qt/mainwindow.ui
+++ b/gui/qt/mainwindow.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1004</width>
+    <width>1050</width>
     <height>1005</height>
    </rect>
   </property>
@@ -4212,14 +4212,14 @@
           <attribute name="horizontalHeaderCascadingSectionResizes">
            <bool>false</bool>
           </attribute>
+          <attribute name="horizontalHeaderMinimumSectionSize">
+           <number>50</number>
+          </attribute>
           <attribute name="horizontalHeaderDefaultSectionSize">
            <number>70</number>
           </attribute>
           <attribute name="horizontalHeaderHighlightSections">
            <bool>false</bool>
-          </attribute>
-          <attribute name="horizontalHeaderMinimumSectionSize">
-           <number>50</number>
           </attribute>
           <attribute name="horizontalHeaderShowSortIndicator" stdset="0">
            <bool>false</bool>
@@ -4363,14 +4363,14 @@
           <property name="cornerButtonEnabled">
            <bool>true</bool>
           </property>
+          <attribute name="horizontalHeaderMinimumSectionSize">
+           <number>50</number>
+          </attribute>
           <attribute name="horizontalHeaderDefaultSectionSize">
            <number>70</number>
           </attribute>
           <attribute name="horizontalHeaderHighlightSections">
            <bool>false</bool>
-          </attribute>
-          <attribute name="horizontalHeaderMinimumSectionSize">
-           <number>50</number>
           </attribute>
           <attribute name="horizontalHeaderShowSortIndicator" stdset="0">
            <bool>false</bool>
@@ -4521,14 +4521,14 @@
           <property name="cornerButtonEnabled">
            <bool>true</bool>
           </property>
+          <attribute name="horizontalHeaderMinimumSectionSize">
+           <number>50</number>
+          </attribute>
           <attribute name="horizontalHeaderDefaultSectionSize">
            <number>70</number>
           </attribute>
           <attribute name="horizontalHeaderHighlightSections">
            <bool>false</bool>
-          </attribute>
-          <attribute name="horizontalHeaderMinimumSectionSize">
-           <number>50</number>
           </attribute>
           <attribute name="horizontalHeaderShowSortIndicator" stdset="0">
            <bool>false</bool>
@@ -4659,14 +4659,14 @@
              <property name="cornerButtonEnabled">
               <bool>false</bool>
              </property>
+             <attribute name="horizontalHeaderMinimumSectionSize">
+              <number>40</number>
+             </attribute>
              <attribute name="horizontalHeaderDefaultSectionSize">
               <number>100</number>
              </attribute>
              <attribute name="horizontalHeaderHighlightSections">
               <bool>false</bool>
-             </attribute>
-             <attribute name="horizontalHeaderMinimumSectionSize">
-              <number>40</number>
              </attribute>
              <attribute name="horizontalHeaderShowSortIndicator" stdset="0">
               <bool>false</bool>
@@ -4784,14 +4784,14 @@
              <property name="cornerButtonEnabled">
               <bool>false</bool>
              </property>
+             <attribute name="horizontalHeaderMinimumSectionSize">
+              <number>40</number>
+             </attribute>
              <attribute name="horizontalHeaderDefaultSectionSize">
               <number>100</number>
              </attribute>
              <attribute name="horizontalHeaderHighlightSections">
               <bool>false</bool>
-             </attribute>
-             <attribute name="horizontalHeaderMinimumSectionSize">
-              <number>40</number>
              </attribute>
              <attribute name="horizontalHeaderShowSortIndicator" stdset="0">
               <bool>false</bool>
@@ -4940,14 +4940,14 @@
              <property name="cornerButtonEnabled">
               <bool>false</bool>
              </property>
+             <attribute name="horizontalHeaderMinimumSectionSize">
+              <number>40</number>
+             </attribute>
              <attribute name="horizontalHeaderDefaultSectionSize">
               <number>100</number>
              </attribute>
              <attribute name="horizontalHeaderHighlightSections">
               <bool>false</bool>
-             </attribute>
-             <attribute name="horizontalHeaderMinimumSectionSize">
-              <number>40</number>
              </attribute>
              <attribute name="horizontalHeaderShowSortIndicator" stdset="0">
               <bool>false</bool>
@@ -5050,14 +5050,14 @@
              <property name="cornerButtonEnabled">
               <bool>false</bool>
              </property>
+             <attribute name="horizontalHeaderMinimumSectionSize">
+              <number>40</number>
+             </attribute>
              <attribute name="horizontalHeaderDefaultSectionSize">
               <number>100</number>
              </attribute>
              <attribute name="horizontalHeaderHighlightSections">
               <bool>false</bool>
-             </attribute>
-             <attribute name="horizontalHeaderMinimumSectionSize">
-              <number>40</number>
              </attribute>
              <attribute name="horizontalHeaderShowSortIndicator" stdset="0">
               <bool>false</bool>
@@ -6316,7 +6316,7 @@
        <enum>QTabWidget::Rounded</enum>
       </property>
       <property name="currentIndex">
-       <number>0</number>
+       <number>2</number>
       </property>
       <property name="elideMode">
        <enum>Qt::ElideLeft</enum>
@@ -6499,14 +6499,14 @@
              <property name="wordWrap">
               <bool>false</bool>
              </property>
+             <attribute name="horizontalHeaderMinimumSectionSize">
+              <number>40</number>
+             </attribute>
              <attribute name="horizontalHeaderDefaultSectionSize">
               <number>100</number>
              </attribute>
              <attribute name="horizontalHeaderHighlightSections">
               <bool>false</bool>
-             </attribute>
-             <attribute name="horizontalHeaderMinimumSectionSize">
-              <number>40</number>
              </attribute>
              <attribute name="horizontalHeaderShowSortIndicator" stdset="0">
               <bool>true</bool>
@@ -6612,11 +6612,11 @@
              <attribute name="horizontalHeaderCascadingSectionResizes">
               <bool>true</bool>
              </attribute>
-             <attribute name="horizontalHeaderDefaultSectionSize">
-              <number>70</number>
-             </attribute>
              <attribute name="horizontalHeaderMinimumSectionSize">
               <number>50</number>
+             </attribute>
+             <attribute name="horizontalHeaderDefaultSectionSize">
+              <number>70</number>
              </attribute>
              <attribute name="horizontalHeaderStretchLastSection">
               <bool>true</bool>
@@ -8630,6 +8630,16 @@ QPushButton:pressed {
                 </widget>
                </item>
                <item>
+                <widget class="QRadioButton" name="radioSmartPadKeys">
+                 <property name="focusPolicy">
+                  <enum>Qt::NoFocus</enum>
+                 </property>
+                 <property name="text">
+                  <string>SmartPad</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
                 <widget class="QRadioButton" name="radioCustomKeys">
                  <property name="sizePolicy">
                   <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -9495,14 +9505,14 @@ QPushButton:pressed {
           <property name="cornerButtonEnabled">
            <bool>true</bool>
           </property>
+          <attribute name="horizontalHeaderMinimumSectionSize">
+           <number>50</number>
+          </attribute>
           <attribute name="horizontalHeaderDefaultSectionSize">
            <number>70</number>
           </attribute>
           <attribute name="horizontalHeaderHighlightSections">
            <bool>false</bool>
-          </attribute>
-          <attribute name="horizontalHeaderMinimumSectionSize">
-           <number>50</number>
           </attribute>
           <attribute name="horizontalHeaderShowSortIndicator" stdset="0">
            <bool>true</bool>
@@ -9650,8 +9660,8 @@ QPushButton:pressed {
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>1004</width>
-     <height>22</height>
+     <width>1050</width>
+     <height>21</height>
     </rect>
    </property>
    <property name="sizePolicy">

--- a/gui/qt/settings.cpp
+++ b/gui/qt/settings.cpp
@@ -99,6 +99,7 @@ const QString MainWindow::SETTING_KEYPAD_CEMU               = QStringLiteral("ce
 const QString MainWindow::SETTING_KEYPAD_TILEM              = QStringLiteral("tilem");
 const QString MainWindow::SETTING_KEYPAD_WABBITEMU          = QStringLiteral("wabbitemu");
 const QString MainWindow::SETTING_KEYPAD_JSTIFIED           = QStringLiteral("jsTIfied");
+const QString MainWindow::SETTING_KEYPAD_SMARTPAD               = QStringLiteral("SmartPad");
 const QString MainWindow::SETTING_KEYPAD_CUSTOM             = QStringLiteral("custom");
 
 const QString MainWindow::SETTING_PREFERRED_LANG            = QStringLiteral("preferred_lang");
@@ -804,6 +805,8 @@ void MainWindow::keymapChanged() {
         setKeymap(SETTING_KEYPAD_WABBITEMU);
     } else if (ui->radiojsTIfiedKeys->isChecked()) {
         setKeymap(SETTING_KEYPAD_JSTIFIED);
+    } else if (ui->radioSmartPadKeys->isChecked()) {
+        setKeymap(SETTING_KEYPAD_SMARTPAD);
     } else if (ui->radioCustomKeys->isChecked()) {
         setKeymap(SETTING_KEYPAD_CUSTOM);
     }
@@ -831,6 +834,8 @@ void MainWindow::setKeymap(const QString &value) {
         mode = QtKeypadBridge::KEYMAP_WABBITEMU;
     } else if (!SETTING_KEYPAD_JSTIFIED.compare(map, Qt::CaseInsensitive)) {
         mode = QtKeypadBridge::KEYMAP_JSTIFIED;
+    } else if (!SETTING_KEYPAD_SMARTPAD.compare(map, Qt::CaseInsensitive)) {
+        mode = QtKeypadBridge::KEYMAP_SMARTPAD;
     } else {
         mode = QtKeypadBridge::KEYMAP_CUSTOM;
     }
@@ -853,6 +858,8 @@ void MainWindow::keymapLoad() {
         ui->radioWabbitemuKeys->setChecked(true);
     } else if (!SETTING_KEYPAD_JSTIFIED.compare(currKeyMap, Qt::CaseInsensitive)) {
         ui->radiojsTIfiedKeys->setChecked(true);
+    } else if (!SETTING_KEYPAD_SMARTPAD.compare(currKeyMap, Qt::CaseInsensitive)) {
+        ui->radioSmartPadKeys->setChecked(true);
     } else if (!SETTING_KEYPAD_CUSTOM.compare(currKeyMap, Qt::CaseInsensitive)) {
         ui->radioCustomKeys->setChecked(true);
     }

--- a/gui/qt/settings.cpp
+++ b/gui/qt/settings.cpp
@@ -99,7 +99,7 @@ const QString MainWindow::SETTING_KEYPAD_CEMU               = QStringLiteral("ce
 const QString MainWindow::SETTING_KEYPAD_TILEM              = QStringLiteral("tilem");
 const QString MainWindow::SETTING_KEYPAD_WABBITEMU          = QStringLiteral("wabbitemu");
 const QString MainWindow::SETTING_KEYPAD_JSTIFIED           = QStringLiteral("jsTIfied");
-const QString MainWindow::SETTING_KEYPAD_SMARTPAD               = QStringLiteral("SmartPad");
+const QString MainWindow::SETTING_KEYPAD_SMARTPAD           = QStringLiteral("SmartPad");
 const QString MainWindow::SETTING_KEYPAD_CUSTOM             = QStringLiteral("custom");
 
 const QString MainWindow::SETTING_PREFERRED_LANG            = QStringLiteral("preferred_lang");


### PR DESCRIPTION
Added new option to Key Bindings under the General Settings to select 'SmartPad'. This will allow a user to connect their calculator (running the SmartPad app) to their computer, and control the CEmu Keypad with it.

Testing needed on Windows:
Pressing a key that contains the combination Alt+Ctrl+Win+Shift on Windows 10 will launch the Office application (or a webpage asking you to download Office). I have already disabled this via a [Registry tweak](https://web.archive.org/web/20211125095040/https://www.tenforums.com/microsoft-office-365/154729-disable-shift-ctrl-windows-alt-opening-login-office.html) so I cannot test. I need to be sure this nuisance won't appear on other's machines.