### PR TITLE
Fixes #466

### DIFF
--- a/core/vat.c
+++ b/core/vat.c
@@ -1,6 +1,7 @@
 #include "vat.h"
 #include "mem.h"
 #include "debug/debug.h"
+#include "defines.h"
 
 #include <string.h>
 
@@ -186,6 +187,7 @@ const char *calc_var_name_to_utf8(uint8_t name[8], bool named) {
                     *dest++ = 's';
                     break;
                 }
+                fallthrough;
             default:
                 for (i = 0; i < 8 && ((name[i] >= 'A' && name[i] <= 'Z' + 1)  ||
                                       (name[i] >= 'a' && name[i] <= 'z') ||

--- a/core/vat.c
+++ b/core/vat.c
@@ -80,7 +80,7 @@ static void hex_byte(char **dest, uint8_t byte) {
     *(*dest)++ = hex_char(byte >> 0);
 }
 
-const char *calc_var_name_to_utf8(uint8_t name[8]) {
+const char *calc_var_name_to_utf8(uint8_t name[8], bool named) {
     static char buffer[20];
     char *dest = buffer;
     uint8_t i = 0;
@@ -173,17 +173,19 @@ const char *calc_var_name_to_utf8(uint8_t name[8]) {
                     *dest++ = 'n';
                 }
                 break;
-            case 0x72:
-                *dest++ = 'A';
-                *dest++ = 'n';
-                *dest++ = 's';
-                break;
             case 0xAA:
                 *dest++ = 'S';
                 *dest++ = 't';
                 *dest++ = 'r';
                 *dest++ = '0' + (name[1] + 1) % 10;
                 break;
+            case 0x72:
+                if (!named) {
+                    *dest++ = 'A';
+                    *dest++ = 'n';
+                    *dest++ = 's';
+                    break;
+                }
             default:
                 for (i = 0; i < 8 && ((name[i] >= 'A' && name[i] <= 'Z' + 1)  ||
                                       (name[i] >= 'a' && name[i] <= 'z') ||

--- a/core/vat.h
+++ b/core/vat.h
@@ -76,7 +76,7 @@ typedef enum calc_var_type {
 } calc_var_type_t;
 
 extern const char *calc_var_type_names[0x40];
-const char *calc_var_name_to_utf8(uint8_t name[8]);
+const char *calc_var_name_to_utf8(uint8_t name[8], bool named);
 const char *calc_var_name_to_ascii(uint8_t name[8]);
 
 typedef struct calc_var {

--- a/gui/qt/basicdebugger.cpp
+++ b/gui/qt/basicdebugger.cpp
@@ -178,7 +178,7 @@ MainWindow::debug_basic_status_t MainWindow::debugBasicPgrmLookup(bool allowSwit
         ui->basicTempEdit->clear();
         return DBG_BASIC_NO_EXECUTING_PRGM;
     } else {
-        QString var_name = QString(calc_var_name_to_utf8(reinterpret_cast<uint8_t*>(&name[1])));
+        QString var_name = QString(calc_var_name_to_utf8(reinterpret_cast<uint8_t*>(&name[1]), true));
 
         // lookup in map to see if we've already parsed this file
         if (m_basicPrgmsMap.contains(var_name)) {

--- a/gui/qt/debugger.cpp
+++ b/gui/qt/debugger.cpp
@@ -2325,7 +2325,7 @@ void MainWindow::osUpdate() {
         QTableWidgetItem *varAddr = new QTableWidgetItem(int2hex(var.address, 6));
         QTableWidgetItem *varVatAddr = new QTableWidgetItem(int2hex(var.vat, 6));
         QTableWidgetItem *varSize = new QTableWidgetItem(int2hex(var.size, 4));
-        QTableWidgetItem *varName = new QTableWidgetItem(QString(calc_var_name_to_utf8(var.name)));
+        QTableWidgetItem *varName = new QTableWidgetItem(QString(calc_var_name_to_utf8(var.name, var.named)));
         QTableWidgetItem *varType = new QTableWidgetItem(QString(calc_var_type_names[var.type]));
 
         varAddr->setFont(monospace);

--- a/gui/qt/mainwindow.cpp
+++ b/gui/qt/mainwindow.cpp
@@ -1917,7 +1917,7 @@ void MainWindow::varShow() {
                     var_type_str += QStringLiteral(" (ASM)");
                 }
 
-                QTableWidgetItem *var_name = new QTableWidgetItem(calc_var_name_to_utf8(var.name));
+                QTableWidgetItem *var_name = new QTableWidgetItem(calc_var_name_to_utf8(var.name, var.named));
                 QTableWidgetItem *var_location = new QTableWidgetItem(var.archived ? tr("Archive") : QStringLiteral("RAM"));
                 QTableWidgetItem *var_type = new QTableWidgetItem(var_type_str);
                 QTableWidgetItem *var_preview = new QTableWidgetItem(var_value);
@@ -2008,7 +2008,7 @@ void MainWindow::varSaveSelectedFiles() {
         if (ui->emuVarView->item(currRow, VAR_NAME_COL)->checkState() == Qt::Checked) {
             calc_var_t var = ui->emuVarView->item(currRow, VAR_NAME_COL)->data(Qt::UserRole).value<calc_var_t>();
 
-            name = QString(calc_var_name_to_utf8(var.name));
+            name = QString(calc_var_name_to_utf8(var.name, var.named));
             filename = dialog.directory().absolutePath() + "/" + name + "." + m_varExtensions[var.type1];
 
             if (emu_receive_variable(filename.toStdString().c_str(), &var, 1) != LINK_GOOD) {


### PR DESCRIPTION
Made the following changes:
* Added a `named` parameter to the `calc_var_name_to_utf8()` in `core/vat.c`

This fixes issue `Variables that start with r show up as Ans in the Variable Viewer #466` by making the conversion to Ans dependent on whether the variable is parsed as having a true `calc_var_t.named` attribute. The `calc_var_t.named` attribute for Ans is false, so the conversion does not take place.

![CEmu](https://github.com/CE-Programming/CEmu/assets/57052406/2baf3037-b921-457f-9062-6ea16a50aea9)


The solution does rely on a switch-case fall-through, raising a compiler warning, which will be fixed pending review.