### PR TITLE
Dark mode improvements

### DIFF
--- a/gui/qt/basiccodeviewerwindow.cpp
+++ b/gui/qt/basiccodeviewerwindow.cpp
@@ -26,6 +26,14 @@ BasicEditor::BasicEditor(QWidget *parent) : QPlainTextEdit(parent)
     updateLineNumberAreaWidth(0);
 }
 
+void BasicEditor::updateDarkMode()
+{
+    if (highlighter != nullptr) {
+        delete highlighter;
+        highlighter = new BasicHighlighter(document());
+    }
+}
+
 void BasicEditor::toggleHighlight()
 {
     if (highlighter == nullptr) {

--- a/gui/qt/basiccodeviewerwindow.h
+++ b/gui/qt/basiccodeviewerwindow.h
@@ -62,6 +62,7 @@ class BasicEditor : public QPlainTextEdit
 public:
     BasicEditor(QWidget *parent = nullptr);
 
+    void updateDarkMode();
     void lineNumberAreaPaintEvent(QPaintEvent *event);
     int lineNumberAreaWidth();
     void toggleHighlight();

--- a/gui/qt/datawidget.cpp
+++ b/gui/qt/datawidget.cpp
@@ -6,8 +6,15 @@
 
 DataWidget::DataWidget(QWidget *parent) : QPlainTextEdit{parent} {
     moveable = false;
-    currentLineColor = isRunningInDarkMode() ? QColor(Qt::black) : QColor(Qt::yellow).lighter(160);
     setContextMenuPolicy(Qt::CustomContextMenu);
+}
+
+void DataWidget::updateDarkMode() {
+    bool darkMode = isRunningInDarkMode();
+    for (QTextEdit::ExtraSelection &selection : highlights) {
+        selection.format.setBackground(selection.format.colorProperty(QTextFormat::UserProperty + darkMode));
+    }
+    updateAllHighlights();
 }
 
 void DataWidget::clearAllHighlights() {
@@ -50,15 +57,17 @@ bool DataWidget::labelCheck() {
 void DataWidget::cursorState(bool state) {
     moveable = state;
     if (moveable) {
-        addHighlight(currentLineColor);
+        addHighlight(QColor(Qt::yellow).lighter(160), Qt::black);
     }
 }
 
-void DataWidget::addHighlight(const QColor &color) {
+void DataWidget::addHighlight(const QColor &lightModeColor, const QColor &darkModeColor) {
     QTextEdit::ExtraSelection selection;
 
-    selection.format.setBackground(color);
+    selection.format.setBackground(isRunningInDarkMode() ? darkModeColor : lightModeColor);
     selection.format.setProperty(QTextFormat::FullWidthSelection, true);
+    selection.format.setProperty(QTextFormat::UserProperty, lightModeColor);
+    selection.format.setProperty(QTextFormat::UserProperty + 1, darkModeColor);
     selection.cursor = textCursor();
     selection.cursor.movePosition(QTextCursor::StartOfLine);
 
@@ -70,7 +79,7 @@ void DataWidget::highlightCurrentLine() {
         if (!highlights.isEmpty()) {
             highlights.removeLast();
         }
-        addHighlight(currentLineColor);
+        addHighlight(QColor(Qt::yellow).lighter(160), Qt::black);
         setExtraSelections(highlights);
         if (QApplication::keyboardModifiers().testFlag(Qt::ControlModifier)) {
             bool ok = true;

--- a/gui/qt/datawidget.h
+++ b/gui/qt/datawidget.h
@@ -16,9 +16,10 @@ class DataWidget : public QPlainTextEdit {
 
 public:
     explicit DataWidget(QWidget *p = Q_NULLPTR);
+    void updateDarkMode();
     void clearAllHighlights();
     void updateAllHighlights();
-    void addHighlight(const QColor& color);
+    void addHighlight(const QColor &lightModeColor, const QColor &darkModeColor);
     void highlightCurrentLine();
     void cursorState(bool movable);
     bool labelCheck();
@@ -30,7 +31,6 @@ signals:
 
 private:
     bool moveable;
-    QColor currentLineColor;
     QList<QTextEdit::ExtraSelection> highlights;
 };
 

--- a/gui/qt/datawidget.h
+++ b/gui/qt/datawidget.h
@@ -2,6 +2,9 @@
 #define CODEEDITOR_H
 
 #include <QtWidgets/QPlainTextEdit>
+#include <QtGui/QSyntaxHighlighter>
+#include <QtGui/QTextCharFormat>
+#include <QtCore/QRegularExpression>
 #include <QtCore/QObject>
 
 QT_BEGIN_NAMESPACE
@@ -10,6 +13,40 @@ QT_BEGIN_NAMESPACE
     class QSize;
     class QWidget;
 QT_END_NAMESPACE
+
+class AsmHighlighter : public QSyntaxHighlighter
+{
+    Q_OBJECT
+
+public:
+    AsmHighlighter(QTextDocument *parent = nullptr);
+
+protected:
+    void highlightBlock(const QString &text) Q_DECL_OVERRIDE;
+
+private:
+    struct HighlightingRule
+    {
+        QRegularExpression pattern;
+        QTextCharFormat format;
+    };
+    QVector<HighlightingRule> highlightingRules;
+
+    QTextCharFormat addressFormat;
+    QTextCharFormat symbolFormat;
+    QTextCharFormat watchRFormat;
+    QTextCharFormat watchWFormat;
+    QTextCharFormat breakPFormat;
+    QTextCharFormat bytesFormat;
+    QTextCharFormat mnemonicFormat;
+    QTextCharFormat hexFormat;
+    QTextCharFormat decimalFormat;
+    QTextCharFormat parenFormat;
+    QTextCharFormat registerFormat;
+
+    QRegularExpression labelPattern;
+    QRegularExpression instructionPattern;
+};
 
 class DataWidget : public QPlainTextEdit {
     Q_OBJECT
@@ -31,6 +68,7 @@ signals:
 
 private:
     bool moveable;
+    AsmHighlighter *highlighter;
     QList<QTextEdit::ExtraSelection> highlights;
 };
 

--- a/gui/qt/debugger/disasm.cpp
+++ b/gui/qt/debugger/disasm.cpp
@@ -23,11 +23,7 @@ static std::string strW(uint32_t data) {
     if (high) {
         range = disasm.map.equal_range(data);
         for (sit = range.first; sit != range.second; ++sit) {
-            if (disasm.bold_sym) {
-                ret += "<b>" + sit->second + "</b>";
-            } else {
-                ret += sit->second;
-            }
+            ret += sit->second;
             ret += '|';
         }
         if (!ret.empty()) {
@@ -37,11 +33,7 @@ static std::string strW(uint32_t data) {
         if (!disasm.il) {
             range = disasm.map.equal_range(cpu.registers.MBASE<<16|data);
             for (sit = range.first; sit != range.second; ++sit) {
-                if (disasm.bold_sym) {
-                    ret += "<b>" + sit->second + "</b>";
-                } else {
-                    ret += sit->second;
-                }
+                ret += sit->second;
                 ret += '|';
             }
             if (!ret.empty()) {
@@ -67,11 +59,7 @@ static std::string strA(uint32_t data) {
             if (!ret.empty()) {
                 ret += '|';
             }
-            if (disasm.bold_sym) {
-                ret += "<b>" + sit->second + "</b>";
-            } else {
-                ret += sit->second;
-            }
+            ret += sit->second;
         }
     }
     if (!ret.empty()) {
@@ -86,11 +74,7 @@ static std::string strA(uint32_t data) {
                 if (!ret.empty()) {
                     ret += '|';
                 }
-                if (disasm.bold_sym) {
-                    ret += "<b>" + sit->second + "</b>";
-                } else {
-                    ret += sit->second;
-                }
+                ret += sit->second;
             }
         }
         if (!ret.empty()) {

--- a/gui/qt/mainwindow.cpp
+++ b/gui/qt/mainwindow.cpp
@@ -85,6 +85,11 @@ MainWindow::MainWindow(CEmuOpts &cliOpts, QWidget *p) : QMainWindow(p), ui(new U
 
     ui->setupUi(this);
 
+#if (QT_VERSION < QT_VERSION_CHECK(6, 1, 0))
+    m_styleForMode[0] = m_styleForMode[1] = QApplication::style()->objectName();
+#else
+    m_styleForMode[0] = m_styleForMode[1] = QApplication::style()->name();
+#endif
     darkModeSwitch(isSystemInDarkMode());
 
     setStyleSheet(QStringLiteral("QMainWindow::separator{ width: 0px; height: 0px; }"));
@@ -882,10 +887,14 @@ void MainWindow::translateExtras(int init) {
 }
 
 void MainWindow::darkModeSwitch(bool darkMode) {
+    QApplication::setStyle(m_styleForMode[darkMode]);
+    if (darkMode != isRunningInDarkMode()) {
+        m_styleForMode[darkMode] = QStringLiteral("fusion");
+        QApplication::setStyle(m_styleForMode[darkMode]);
+        darkMode = isRunningInDarkMode();
+    }
+
     m_isInDarkMode = darkMode;
-#ifdef Q_OS_WIN
-    QApplication::setStyle(darkMode ? "fusion" : "windowsvista");
-#endif
     if (darkMode) {
         m_cBack.setColor(QPalette::Base, QColor(Qt::blue).lighter(180));
         m_cBack.setColor(QPalette::Text, Qt::black);

--- a/gui/qt/mainwindow.cpp
+++ b/gui/qt/mainwindow.cpp
@@ -886,7 +886,6 @@ void MainWindow::darkModeSwitch(bool darkMode) {
 #ifdef Q_OS_WIN
     QApplication::setStyle(darkMode ? "fusion" : "windowsvista");
 #endif
-    m_disasmOpcodeColor = darkMode ? "darkorange" : "darkblue";
     if (darkMode) {
         m_cBack.setColor(QPalette::Base, QColor(Qt::blue).lighter(180));
         m_cBack.setColor(QPalette::Text, Qt::black);
@@ -2389,15 +2388,14 @@ void MainWindow::disasmLine() {
 
         QString line;
         QString symbols;
-        QString highlighted;
 
         if (useLabel) {
             if (disasm.base > 511 || (disasm.base < 512 && sit->second[0] == '_')) {
-                line = QString(QStringLiteral("<pre><b><font color='#444'>%1</font></b>     %2</pre>"))
-                                        .arg(int2hex(static_cast<uint32_t>(disasm.base), 6),
-                                             QString::fromStdString(disasm.bold_sym ? "<b>" + sit->second + "</b>" : sit->second) + ":");
+                line = QStringLiteral("%1  %2:")
+                       .arg(disasm.addr ? int2hex(static_cast<uint32_t>(disasm.base), 6) : QString(),
+                            QString::fromStdString(sit->second));
 
-                m_disasm->appendHtml(line);
+                m_disasm->appendPlainText(line);
             }
 
             if (numLines == j + 1) {
@@ -2405,25 +2403,16 @@ void MainWindow::disasmLine() {
             }
             sit++;
         } else {
-            symbols = QString(QStringLiteral("<b><font color='#008000'>%1</font><font color='#808000'>%2</font><font color='#800000'>%3</font></b>"))
-                             .arg((disasm.highlight.watchR  ? QStringLiteral("R") : QStringLiteral(" ")),
-                                  (disasm.highlight.watchW ? QStringLiteral("W") : QStringLiteral(" ")),
-                                  (disasm.highlight.breakP  ? QStringLiteral("X") : QStringLiteral(" ")));
-
-            highlighted = QString::fromStdString(disasm.instr.operands)
-                                  .replace(QRegularExpression(QStringLiteral("(\\$[0-9a-fA-F]+)")), QStringLiteral("<font color='green'>\\1</font>")) // hex numbers
-                                  .replace(QRegularExpression(QStringLiteral("(^\\d)")), QStringLiteral("<font color='blue'>\\1</font>"))             // dec number
-                                  .replace(QRegularExpression(QStringLiteral("([()])")), QStringLiteral("<font color='#600'>\\1</font>"));            // parentheses
-
-            line = QString(QStringLiteral("<pre><b><font color='#444'>%1</font></b> %2 %3  <font color='%4'>%5</font> %6</pre>"))
+            line = QString(QStringLiteral("%1 %2%3%4 %5  %6 %7"))
                            .arg(disasm.addr ? int2hex(static_cast<uint32_t>(disasm.base), 6) : QString(),
-                                symbols,
+                                disasm.highlight.watchR ? QStringLiteral("R") : QStringLiteral(" "),
+                                disasm.highlight.watchW ? QStringLiteral("W") : QStringLiteral(" "),
+                                disasm.highlight.breakP ? QStringLiteral("X") : QStringLiteral(" "),
                                 disasm.bytes ? QString::fromStdString(disasm.instr.data).leftJustified(12, ' ') : QStringLiteral(" "),
-                                m_disasmOpcodeColor,
                                 QString::fromStdString(disasm.instr.opcode),
-                                highlighted);
+                                QString::fromStdString(disasm.instr.operands));
 
-            m_disasm->appendHtml(line);
+            m_disasm->appendPlainText(line);
         }
     }
 

--- a/gui/qt/mainwindow.h
+++ b/gui/qt/mainwindow.h
@@ -573,7 +573,6 @@ private:
     InterCom com;
 
     bool m_isInDarkMode = false;
-    const char* m_disasmOpcodeColor;
 
     int m_watchGUIMask = DBG_MASK_NONE;
 

--- a/gui/qt/mainwindow.h
+++ b/gui/qt/mainwindow.h
@@ -214,6 +214,9 @@ private:
     void translateExtras(int init);
     void translateSwitch(const QString &lang);
 
+    // dark mode
+    void darkModeSwitch(bool darkMode);
+
     // state slots
     void stateAdd(QString &name, QString &path);
     void stateAddNew();

--- a/gui/qt/mainwindow.h
+++ b/gui/qt/mainwindow.h
@@ -704,6 +704,8 @@ private:
     bool m_timerEmuTriggered = false;
     bool m_timerFpsTriggered = false;
 
+    QString m_styleForMode[2];
+
     QFont varPreviewCEFont;
     QFont varPreviewItalicFont;
 

--- a/gui/qt/mainwindow.ui
+++ b/gui/qt/mainwindow.ui
@@ -2842,15 +2842,6 @@
                         </color>
                        </brush>
                       </colorrole>
-                      <colorrole role="Text">
-                       <brush brushstyle="SolidPattern">
-                        <color alpha="255">
-                         <red>0</red>
-                         <green>0</green>
-                         <blue>0</blue>
-                        </color>
-                       </brush>
-                      </colorrole>
                      </active>
                      <inactive>
                       <colorrole role="WindowText">
@@ -2862,27 +2853,9 @@
                         </color>
                        </brush>
                       </colorrole>
-                      <colorrole role="Text">
-                       <brush brushstyle="SolidPattern">
-                        <color alpha="255">
-                         <red>0</red>
-                         <green>0</green>
-                         <blue>0</blue>
-                        </color>
-                       </brush>
-                      </colorrole>
                      </inactive>
                      <disabled>
                       <colorrole role="WindowText">
-                       <brush brushstyle="SolidPattern">
-                        <color alpha="255">
-                         <red>120</red>
-                         <green>120</green>
-                         <blue>120</blue>
-                        </color>
-                       </brush>
-                      </colorrole>
-                      <colorrole role="Text">
                        <brush brushstyle="SolidPattern">
                         <color alpha="255">
                          <red>120</red>
@@ -2919,15 +2892,6 @@
                         </color>
                        </brush>
                       </colorrole>
-                      <colorrole role="Text">
-                       <brush brushstyle="SolidPattern">
-                        <color alpha="255">
-                         <red>0</red>
-                         <green>0</green>
-                         <blue>0</blue>
-                        </color>
-                       </brush>
-                      </colorrole>
                      </active>
                      <inactive>
                       <colorrole role="WindowText">
@@ -2939,27 +2903,9 @@
                         </color>
                        </brush>
                       </colorrole>
-                      <colorrole role="Text">
-                       <brush brushstyle="SolidPattern">
-                        <color alpha="255">
-                         <red>0</red>
-                         <green>0</green>
-                         <blue>0</blue>
-                        </color>
-                       </brush>
-                      </colorrole>
                      </inactive>
                      <disabled>
                       <colorrole role="WindowText">
-                       <brush brushstyle="SolidPattern">
-                        <color alpha="255">
-                         <red>120</red>
-                         <green>120</green>
-                         <blue>120</blue>
-                        </color>
-                       </brush>
-                      </colorrole>
-                      <colorrole role="Text">
                        <brush brushstyle="SolidPattern">
                         <color alpha="255">
                          <red>120</red>

--- a/gui/qt/utils.cpp
+++ b/gui/qt/utils.cpp
@@ -12,6 +12,9 @@
 #include <QtCore/QString>
 #include <QtCore/QTime>
 #include <QtCore/QCoreApplication>
+#include <QtWidgets/QApplication>
+#include <QtGui/QPalette>
+#include <QtGui/QStyleHints>
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
 #include <QtCore/QRandomGenerator>
@@ -82,15 +85,17 @@ int utf8_strlen(const std::string &str) {
 }
 
 bool isRunningInDarkMode() {
-    static bool isDarkMode = false;
-    static bool boolSet = false;
+    QPalette palette = qApp->palette();
+    return palette.window().color().value() < palette.windowText().color().value();
+}
 
-    if (boolSet) {
-        return isDarkMode;
-    }
+bool isSystemInDarkMode() {
+    bool isDarkMode;
 
-    // TODO: handle other OS' way to know if we're running in dark mode
-#if defined(Q_OS_MACX) && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_14
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 5, 0))
+    isDarkMode = qApp->styleHints()->colorScheme() == Qt::ColorScheme::Dark;
+
+#elif defined(Q_OS_MACX) && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_14
     {
         std::array<char, 20> buffer;
         std::string result;
@@ -103,9 +108,12 @@ bool isRunningInDarkMode() {
         }
         isDarkMode = (result == "Dark");
     }
-#endif
 
-    boolSet = true;
+#else
+    // TODO: handle other OS' way to know if we're running in dark mode
+    isDarkMode = isRunningInDarkMode();
+
+#endif
 
     return isDarkMode;
 }

--- a/gui/qt/utils.cpp
+++ b/gui/qt/utils.cpp
@@ -94,25 +94,9 @@ bool isSystemInDarkMode() {
 
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 5, 0))
     isDarkMode = qApp->styleHints()->colorScheme() == Qt::ColorScheme::Dark;
-
-#elif defined(Q_OS_MACX) && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_14
-    {
-        std::array<char, 20> buffer;
-        std::string result;
-        std::unique_ptr<FILE, decltype(&pclose)> pipe(popen("defaults read -g AppleInterfaceStyle", "r"), pclose);
-        while (pipe && fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
-            result += buffer.data();
-        }
-        if (result.back() == '\n') {
-            result.pop_back();
-        }
-        isDarkMode = (result == "Dark");
-    }
-
 #else
     // TODO: handle other OS' way to know if we're running in dark mode
     isDarkMode = isRunningInDarkMode();
-
 #endif
 
     return isDarkMode;

--- a/gui/qt/utils.h
+++ b/gui/qt/utils.h
@@ -27,6 +27,7 @@ std::string calc_var_content_string(const calc_var_t &var);
 int utf8_strlen(const std::string &str);
 
 bool isRunningInDarkMode();
+bool isSystemInDarkMode();
 
 // Qt Specific
 #include <QtCore/QString>


### PR DESCRIPTION
Improve dark mode support in the following ways:
- Support dark theme on Windows Qt6 by switching to Fusion style if applicable
- Improve detection of the current theme in an OS-independent way
- Detect system theme changes dynamically and update colors to match
- Improve dark mode color contrast in various areas of the UI
- Switch to a syntax highlighter for the disassembly view rather than hardcoding HTML, making it easier to style

I'm going ahead and putting up a PR to generate builds for feedback, and to get some testing on MacOS and Linux since I've only been able to test on Windows. In the meantime I may want to look into improving the Fusion style slightly, because some aspects of it seem a little off layout-wise.