### PR TITLE
Big endian support. Fixes #468

### DIFF
--- a/core/cpu.h
+++ b/core/cpu.h
@@ -43,6 +43,7 @@ typedef enum eZ80abort {
 
 typedef union eZ80context {
     uint8_t opcode;
+#if CEMU_BITFIELD_ORDER == CEMU_LITTLE_ENDIAN
     struct {
         uint8_t z : 3;
         uint8_t y : 3;
@@ -54,7 +55,23 @@ typedef union eZ80context {
         uint8_t   : 1;
         uint8_t q : 1;
         uint8_t p : 2;
+        uint8_t   : 2;
     };
+#else
+    struct {
+        uint8_t x : 2;
+        uint8_t y : 3;
+        uint8_t z : 3;
+    };
+    struct {
+        uint8_t   : 2;
+        uint8_t p : 2;
+        uint8_t q : 1;
+        uint8_t   : 1;
+        uint8_t r : 1;
+        uint8_t s : 1;
+    };
+#endif
 } eZ80context_t;
 
 /* eZ80 CPU State */

--- a/core/defines.h
+++ b/core/defines.h
@@ -45,6 +45,53 @@
 # define EMSCRIPTEN_KEEPALIVE
 #endif
 
+#define CEMU_LITTLE_ENDIAN 1
+#define CEMU_BIG_ENDIAN 2
+#ifndef CEMU_BYTE_ORDER
+# if defined(__BYTE_ORDER__)
+#  if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#   define CEMU_BYTE_ORDER CEMU_LITTLE_ENDIAN
+#  elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#   define CEMU_BYTE_ORDER CEMU_BIG_ENDIAN
+#  endif
+# elif defined(_MSC_VER)
+#  define CEMU_BYTE_ORDER CEMU_LITTLE_ENDIAN
+# endif
+#endif
+#if CEMU_BYTE_ORDER != CEMU_LITTLE_ENDIAN && CEMU_BYTE_ORDER != CEMU_BIG_ENDIAN
+# error Endianness not automatically determined, please define CEMU_BYTE_ORDER as CEMU_LITTLE_ENDIAN or CEMU_BIG_ENDIAN.
+#endif
+#ifndef CEMU_BITFIELD_ORDER
+# define CEMU_BITFIELD_ORDER CEMU_BYTE_ORDER
+#endif
+
+#if CEMU_BYTE_ORDER == CEMU_LITTLE_ENDIAN
+# define from_le16(w) (w)
+# define from_le32(w) (w)
+#else
+# if __has_builtin(__builtin_bswap16) || (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)
+#  define from_le16 __builtin_bswap16
+# elif defined(_MSVC)
+#  define from_le16 _byteswap_ushort
+# else
+static inline uint16_t from_le16(uint16_t w) {
+    return ((w & UINT16_C(0xFF00) >> 8) | ((w & UINT16_C(0x00FF) << 8);
+}
+# endif
+# if __has_builtin(__builtin_bswap32) || (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3)
+#  define from_le32 __builtin_bswap32
+# elif defined(_MSVC)
+#  define from_le32 _byteswap_ulong
+# else
+static inline uint32_t from_le32(uint32_t w) {
+    return ((w & UINT32_C(0xFF000000) >> 24) | ((w & UINT32_C(0x00FF0000) >> 8) |
+           ((w & UINT32_C(0x0000FF00) << 8) | ((w & UINT32_C(0x000000FF) << 24);
+}
+# endif
+#endif
+#define to_le16 from_le16
+#define to_le32 from_le32
+
 #define GETMASK(index, size) (((1U << (size)) - 1) << (index))
 #define READFROM(data, index, size) (((data) & GETMASK((index), (size))) >> (index))
 #define WRITE(data, index, size, value) ((data) = ((data) & (~GETMASK((index), (size)))) | ((uint32_t)(value) << (index)))

--- a/core/keypad.h
+++ b/core/keypad.h
@@ -15,13 +15,21 @@ extern "C" {
 typedef struct keypad_state {
     union {
         struct {
-            uint16_t mode : 2, rowWait : 14, scanWait;
+#if CEMU_BITFIELD_ORDER == CEMU_LITTLE_ENDIAN
+            uint32_t mode : 2, rowWait : 14, scanWait : 16;
+#else
+            uint32_t scanWait : 16, rowWait : 14, mode : 2;
+#endif
         };
         uint32_t control;
     };
     union {
         struct {
-            uint8_t rows, cols;
+#if CEMU_BITFIELD_ORDER == CEMU_LITTLE_ENDIAN
+            uint32_t rows : 8, cols : 8, : 16;
+#else
+            uint32_t : 16, cols : 8, rows : 8;
+#endif
         };
         uint32_t size;
     };

--- a/core/lcd.c
+++ b/core/lcd.c
@@ -42,16 +42,16 @@ static inline uint32_t lcd_bgr888swap(uint32_t bgr888, uint32_t mask) {
     return bgr888 ^ diff ^ (diff << 16);
 }
 
-static inline uint32_t lcd_abgr8888out(uint32_t abgr8888) {
-    return abgr8888 | (abgr8888 >> 5 & 0x040004) | (abgr8888 >> 6 & 0x030303);
+static inline uint32_t lcd_argb8888out(uint32_t argb8888) {
+    return argb8888 | (argb8888 >> 5 & 0x040004) | (argb8888 >> 6 & 0x030303);
 }
 
-static inline uint32_t lcd_bgr565out(uint32_t bgr565) {
-    return lcd_abgr8888out(UINT32_C(0xFF000000) | (bgr565 << 8 & 0xF80000) | (bgr565 << 5 & 0xFC00) | (bgr565 << 3 & 0xF8));
+static inline uint32_t lcd_rgb565out(uint32_t rgb565) {
+    return lcd_argb8888out(UINT32_C(0xFF000000) | (rgb565 << 8 & 0xF80000) | (rgb565 << 5 & 0xFC00) | (rgb565 << 3 & 0xF8));
 }
 
-static inline uint32_t lcd_bgr888out(uint32_t bgr888) {
-    return lcd_abgr8888out(UINT32_C(0xFF000000) | (bgr888 & 0xF8FCF8));
+static inline uint32_t lcd_rgb888out(uint32_t rgb888) {
+    return lcd_argb8888out(UINT32_C(0xFF000000) | (rgb888 & 0xF8FCF8));
 }
 
 void emu_set_lcd_callback(bool (*callback)(void*), void *data) {
@@ -86,7 +86,7 @@ void emu_lcd_drawmem(void *output, void *data, void *data_end, uint32_t lcd_cont
     uint32_t *dat;
     uint32_t *dat_end;
 
-    bgr = lcd_control & (1 << 8) ? 0x001F001F : 0;
+    bgr = lcd_control & (1 << 8) ? 0 : 0x001F001F;
     bebo = lcd_control & (1 << 9);
     mode = lcd_control >> 1 & 7;
     out = output;
@@ -110,9 +110,9 @@ void emu_lcd_drawmem(void *output, void *data, void *data_end, uint32_t lcd_cont
                 color = lcd.palette[word >> ((bitpos -= bpp) ^ bi) & mask];
                 color |= (uint32_t)lcd.palette[word >> ((bitpos -= bpp) ^ bi) & mask] << 16;
                 color = lcd_bgr565swap(color, bgr);
-                *out++ = lcd_bgr565out(color);
+                *out++ = lcd_rgb565out(color);
                 if (out == out_end) break;
-                *out++ = lcd_bgr565out(color >> 16);
+                *out++ = lcd_rgb565out(color >> 16);
             } while (bitpos && out != out_end);
         } while (dat < dat_end);
 
@@ -121,9 +121,9 @@ void emu_lcd_drawmem(void *output, void *data, void *data_end, uint32_t lcd_cont
         do {
             word = rotr32(lcd_next_word(&dat), bi);
             word = lcd_bgr565swap(c1555(word), bgr);
-            *out++ = lcd_bgr565out(word);
+            *out++ = lcd_rgb565out(word);
             if (out == out_end) break;
-            *out++ = lcd_bgr565out(word >> 16);
+            *out++ = lcd_rgb565out(word >> 16);
         } while (dat < dat_end);
 
     } else if (mode == 5) {
@@ -131,7 +131,7 @@ void emu_lcd_drawmem(void *output, void *data, void *data_end, uint32_t lcd_cont
         do {
             word = lcd_next_word(&dat);
             word = lcd_bgr888swap(word, bgr);
-            *out++ = lcd_bgr888out(word);
+            *out++ = lcd_rgb888out(word);
         } while (dat < dat_end);
 
     } else if (mode == 6) {
@@ -139,9 +139,9 @@ void emu_lcd_drawmem(void *output, void *data, void *data_end, uint32_t lcd_cont
         do {
             word = rotr32(lcd_next_word(&dat), bi);
             word = lcd_bgr565swap(word, bgr);
-            *out++ = lcd_bgr565out(word);
+            *out++ = lcd_rgb565out(word);
             if (out == out_end) break;
-            *out++ = lcd_bgr565out(word >> 16);
+            *out++ = lcd_rgb565out(word >> 16);
         } while (dat < dat_end);
 
     } else { /* mode == 7 */
@@ -149,9 +149,9 @@ void emu_lcd_drawmem(void *output, void *data, void *data_end, uint32_t lcd_cont
         do {
             word = rotr32(lcd_next_word(&dat), bi);
             word = lcd_bgr565swap(c444(word), bgr);
-            *out++ = lcd_bgr565out(word);
+            *out++ = lcd_rgb565out(word);
             if (out == out_end) break;
-            *out++ = lcd_bgr565out(word >> 16);
+            *out++ = lcd_rgb565out(word >> 16);
         } while (dat < dat_end);
     }
 

--- a/core/lcd.h
+++ b/core/lcd.h
@@ -40,11 +40,17 @@ typedef struct lcd_state {
 
     /* 256x16-bit color palette registers */
     /* 256 palette entries organized as 128 locations of two entries per word */
-    uint16_t palette[0x100];
+    union {
+        uint32_t paletteWords[0x80]; /* For alignment */
+        uint8_t  paletteBytes[0x200];
+    };
 
     /* Cursor image RAM registers */
     /* 256-word wide values defining images overlaid by the hw cursor mechanism */
-    uint32_t crsrImage[0x100];
+    union {
+        uint32_t crsrImageWords[0x100]; /* For alignment */
+        uint8_t  crsrImageBytes[0x400];
+    };
     uint32_t crsrControl;          /* Cursor control register */
     uint32_t crsrConfig;           /* Cursor configuration register */
     uint32_t crsrPalette0;         /* Cursor palette registers */
@@ -62,6 +68,7 @@ typedef struct lcd_state {
     enum lcd_comp compare;
     uint32_t PPL, HSW, HFP, HBP, LPP, VSW, VFP, VBP, PCD, ACB, CPL, LED, LCDBPP, BPP, PPF;
     bool CLKSEL, IVS, IHS, IPC, IOE, LEE, BGR, BEBO, BEPO, WTRMRK;
+    uint16_t palette[0x100];       /* Palette stored as RGB565 in native endianness */
 
     /* Everything above here goes into the state */
     uint32_t *data;                /* Pointer to start of data to start extracting from */

--- a/core/mem.c
+++ b/core/mem.c
@@ -84,12 +84,12 @@ static uint32_t addr_block(uint32_t *addr, int32_t size, void **block, uint32_t 
         *block_size = SIZE_RAM;
     } else if (*addr < 0xE30800) {
         *addr -= 0xE30200;
-        *block = lcd.palette;
-        *block_size = sizeof lcd.palette;
+        *block = lcd.paletteBytes;
+        *block_size = sizeof lcd.paletteBytes;
     } else {
         *addr -= 0xE30800;
-        *block = lcd.crsrImage;
-        *block_size = sizeof lcd.crsrImage;
+        *block = lcd.crsrImageBytes;
+        *block_size = sizeof lcd.crsrImageBytes;
     }
     return *addr + (unsigned int)size;
 }

--- a/core/os/os-emscripten.c
+++ b/core/os/os-emscripten.c
@@ -86,8 +86,8 @@ void EMSCRIPTEN_KEEPALIVE set_file_to_send(const char* path) {
     strcpy(file_buf, path);
 }
 
-uint8_t* EMSCRIPTEN_KEEPALIVE lcd_get_frame() {
-    return &(panel.display[0][0][0]);
+uint32_t* EMSCRIPTEN_KEEPALIVE lcd_get_frame() {
+    return &(panel.display[0][0]);
 }
 
 int EMSCRIPTEN_KEEPALIVE emsc_set_main_loop_timing(int mode, int value) {

--- a/core/panel.c
+++ b/core/panel.c
@@ -1185,8 +1185,10 @@ static void panel_write_cmd(uint8_t value) {
 static void panel_write_param(uint8_t value) {
     if (likely(panel.paramIter < panel.paramEnd)) {
         uint8_t index = panel.paramIter++;
+#if CEMU_BYTE_ORDER == CEMU_LITTLE_ENDIAN
         /* Swap endianness of word parameters */
         index ^= (index < offsetof(panel_params_t, MADCTL));
+#endif
         uint8_t oldValue = ((uint8_t*)&panel.params)[index];
         ((uint8_t*)&panel.params)[index] = value;
         if (index >= offsetof(panel_params_t, CASET) && index < offsetof(panel_params_t, COLMOD)) {

--- a/core/panel.h
+++ b/core/panel.h
@@ -48,52 +48,70 @@ typedef struct panel_mem_ptr {
     uint16_t yAddr;
 } panel_mem_ptr_t;
 
+#if CEMU_BITFIELD_ORDER == CEMU_LITTLE_ENDIAN
+# define PARAM_BYTE_LOW(NAME, WIDTH)    \
+    uint8_t NAME : WIDTH;               \
+    uint8_t : 8 - WIDTH
+#else
+# define PARAM_BYTE_LOW(NAME, WIDTH)    \
+    uint8_t : 8 - WIDTH;                \
+    uint8_t NAME : WIDTH
+#endif
+
 typedef struct panel_gamma {
+#if CEMU_BITFIELD_ORDER == CEMU_LITTLE_ENDIAN
     uint8_t V0 : 4;
     uint8_t V63 : 4;
+#else
+    uint8_t V63 : 4;
+    uint8_t V0 : 4;
+#endif
 
-    uint8_t V1 : 6;
-    uint8_t : 2;
+    PARAM_BYTE_LOW(V1, 6);
+    PARAM_BYTE_LOW(V2, 6);
+    PARAM_BYTE_LOW(V4, 5);
+    PARAM_BYTE_LOW(V6, 5);
 
-    uint8_t V2 : 6;
-    uint8_t : 2;
-
-    uint8_t V4 : 5;
-    uint8_t : 3;
-
-    uint8_t V6 : 5;
-    uint8_t : 3;
-
+#if CEMU_BITFIELD_ORDER == CEMU_LITTLE_ENDIAN
     uint8_t V13 : 4;
     uint8_t J0 : 2;
     uint8_t : 2;
+#else
+    uint8_t : 2;
+    uint8_t J0 : 2;
+    uint8_t V13 : 4;
+#endif
 
-    uint8_t V20 : 7;
-    uint8_t : 1;
+    PARAM_BYTE_LOW(V20, 7);
 
+#if CEMU_BITFIELD_ORDER == CEMU_LITTLE_ENDIAN
     uint8_t V27 : 3;
     uint8_t : 1;
     uint8_t V36 : 3;
     uint8_t : 1;
-
-    uint8_t V43 : 7;
+#else
     uint8_t : 1;
+    uint8_t V36 : 3;
+    uint8_t : 1;
+    uint8_t V27 : 3;
+#endif
 
+    PARAM_BYTE_LOW(V43, 7);
+
+#if CEMU_BITFIELD_ORDER == CEMU_LITTLE_ENDIAN
     uint8_t V50 : 4;
     uint8_t J1 : 2;
     uint8_t : 2;
-
-    uint8_t V57 : 5;
-    uint8_t : 3;
-
-    uint8_t V59 : 5;
-    uint8_t : 3;
-
-    uint8_t V61 : 6;
+#else
     uint8_t : 2;
+    uint8_t J1 : 2;
+    uint8_t V50 : 4;
+#endif
 
-    uint8_t V62 : 6;
-    uint8_t : 2;
+    PARAM_BYTE_LOW(V57, 5);
+    PARAM_BYTE_LOW(V59, 5);
+    PARAM_BYTE_LOW(V61, 6);
+    PARAM_BYTE_LOW(V62, 6);
 } panel_gamma_t;
 
 typedef struct panel_params {
@@ -123,6 +141,7 @@ typedef struct panel_params {
     } RASET;
     /* Byte params */
     struct {
+#if CEMU_BITFIELD_ORDER == CEMU_LITTLE_ENDIAN
         uint8_t : 2;
         uint8_t MH : 1;
         uint8_t RGB : 1;
@@ -130,35 +149,69 @@ typedef struct panel_params {
         uint8_t MV : 1;
         uint8_t MX : 1;
         uint8_t MY : 1;
+#else
+        uint8_t MY : 1;
+        uint8_t MX : 1;
+        uint8_t MV : 1;
+        uint8_t ML : 1;
+        uint8_t RGB : 1;
+        uint8_t MH : 1;
+        uint8_t : 2;
+#endif
     } MADCTL;
     struct {
+#if CEMU_BITFIELD_ORDER == CEMU_LITTLE_ENDIAN
         uint8_t MCU : 3;
         uint8_t : 1;
         uint8_t RGB : 3;
         uint8_t : 1;
+#else
+        uint8_t : 1;
+        uint8_t RGB : 3;
+        uint8_t : 1;
+        uint8_t MCU : 3;
+#endif
     } COLMOD;
     struct {
         uint8_t DBV;
     } DISBV;
     struct {
+#if CEMU_BITFIELD_ORDER == CEMU_LITTLE_ENDIAN
         uint8_t : 2;
         uint8_t BL : 1;
         uint8_t DD : 1;
         uint8_t : 1;
         uint8_t BCTRL : 1;
         uint8_t : 2;
+#else
+        uint8_t : 2;
+        uint8_t BCTRL : 1;
+        uint8_t : 1;
+        uint8_t DD : 1;
+        uint8_t BL : 1;
+        uint8_t : 2;
+#endif
     } CTRLD;
     struct {
+#if CEMU_BITFIELD_ORDER == CEMU_LITTLE_ENDIAN
         uint8_t C : 2;
         uint8_t : 2;
         uint8_t CE : 2;
         uint8_t : 1;
         uint8_t CECTRL : 1;
+#else
+        uint8_t CECTRL : 1;
+        uint8_t : 1;
+        uint8_t CE : 2;
+        uint8_t : 2;
+        uint8_t C : 2;
+#endif
     } CACE;
     struct {
         uint8_t CMB;
     } CABCMB;
     struct {
+#if CEMU_BITFIELD_ORDER == CEMU_LITTLE_ENDIAN
         uint8_t DM : 2;
         uint8_t : 2;
         uint8_t RM : 1;
@@ -170,8 +223,22 @@ typedef struct panel_params {
         uint8_t EPF : 2;
         uint8_t WEMODE0 : 1;
         uint8_t WEMODE1 : 1;
+#else
+        uint8_t : 3;
+        uint8_t RM : 1;
+        uint8_t : 2;
+        uint8_t DM : 2;
+
+        uint8_t WEMODE1 : 1;
+        uint8_t WEMODE0 : 1;
+        uint8_t EPF : 2;
+        uint8_t ENDIAN : 1;
+        uint8_t RIM : 1;
+        uint8_t MDT : 2;
+#endif
     } RAMCTRL;
     struct {
+#if CEMU_BITFIELD_ORDER == CEMU_LITTLE_ENDIAN
         uint8_t EPL : 1;
         uint8_t DPL : 1;
         uint8_t HSPL : 1;
@@ -179,30 +246,40 @@ typedef struct panel_params {
         uint8_t : 1;
         uint8_t RCM : 2;
         uint8_t WO : 1;
-
-        uint8_t VBP : 7;
+#else
+        uint8_t WO : 1;
+        uint8_t RCM : 2;
         uint8_t : 1;
+        uint8_t VSPL : 1;
+        uint8_t HSPL : 1;
+        uint8_t DPL : 1;
+        uint8_t EPL : 1;
+#endif
 
-        uint8_t HBP : 5;
-        uint8_t : 3;
+        PARAM_BYTE_LOW(VBP, 7);
+        PARAM_BYTE_LOW(HBP, 5);
     } RGBCTRL;
     struct {
-        uint8_t BPA : 7;
-        uint8_t : 1;
+        PARAM_BYTE_LOW(BPA, 7);
+        PARAM_BYTE_LOW(FPA, 7);
+        PARAM_BYTE_LOW(PSEN, 1);
 
-        uint8_t FPA : 7;
-        uint8_t : 1;
-
-        uint8_t PSEN : 1;
-        uint8_t : 7;
-
+#if CEMU_BITFIELD_ORDER == CEMU_LITTLE_ENDIAN
         uint8_t FPB : 4;
         uint8_t BPB : 4;
 
         uint8_t FPC : 4;
         uint8_t BPC : 4;
+#else
+        uint8_t BPB : 4;
+        uint8_t FPB : 4;
+
+        uint8_t BPC : 4;
+        uint8_t FPC : 4;
+#endif
     } PORCTRL;
     struct {
+#if CEMU_BITFIELD_ORDER == CEMU_LITTLE_ENDIAN
         uint8_t DIV : 2;
         uint8_t : 2;
         uint8_t FRSEN : 1;
@@ -213,43 +290,77 @@ typedef struct panel_params {
 
         uint8_t RTNC : 5;
         uint8_t NLC : 3;
+#else
+        uint8_t : 3;
+        uint8_t FRSEN : 1;
+        uint8_t : 2;
+        uint8_t DIV : 2;
+
+        uint8_t NLB : 3;
+        uint8_t RTNB : 5;
+
+        uint8_t NLC : 3;
+        uint8_t RTNC : 5;
+#endif
     } FRCTRL1;
     struct {
+#if CEMU_BITFIELD_ORDER == CEMU_LITTLE_ENDIAN
         uint8_t ISC : 4;
         uint8_t PTGISC : 1;
         uint8_t : 2;
         uint8_t NDL : 1;
+#else
+        uint8_t NDL : 1;
+        uint8_t : 2;
+        uint8_t PTGISC : 1;
+        uint8_t ISC : 4;
+#endif
     } PARCTRL;
     struct {
+#if CEMU_BITFIELD_ORDER == CEMU_LITTLE_ENDIAN
         uint8_t VGLS : 3;
         uint8_t : 1;
         uint8_t VGHS : 3;
         uint8_t : 1;
+#else
+        uint8_t : 1;
+        uint8_t VGHS : 3;
+        uint8_t : 1;
+        uint8_t VGLS : 3;
+#endif
     } GCTRL;
     struct {
         uint8_t PAD_2A;
         uint8_t PAD_2B;
+        PARAM_BYTE_LOW(GTA, 6);
 
-        uint8_t GTA : 6;
-        uint8_t : 2;
-
+#if CEMU_BITFIELD_ORDER == CEMU_LITTLE_ENDIAN
         uint8_t GOF : 4;
         uint8_t GOFR : 4;
+#else
+        uint8_t GOFR : 4;
+        uint8_t GOF : 4;
+#endif
     } GTADJ;
     struct {
-        uint8_t VCOMS : 6;
-        uint8_t : 2;
+        PARAM_BYTE_LOW(VCOMS, 6);
     } VCOMS;
     struct {
+#if CEMU_BITFIELD_ORDER == CEMU_LITTLE_ENDIAN
         uint8_t IS : 1;
         uint8_t NS : 1;
         uint8_t : 6;
+#else
+        uint8_t : 6;
+        uint8_t NS : 1;
+        uint8_t IS : 1;
+#endif
     } POWSAVE;
     struct {
-        uint8_t DOFSAVE : 1;
-        uint8_t : 7;
+        PARAM_BYTE_LOW(DOFSAVE, 1);
     } DLPOFFSAVE;
     struct {
+#if CEMU_BITFIELD_ORDER == CEMU_LITTLE_ENDIAN
         uint8_t XGS : 1;
         uint8_t XMV : 1;
         uint8_t XMH : 1;
@@ -258,6 +369,16 @@ typedef struct panel_params {
         uint8_t XBGR : 1;
         uint8_t XMY : 1;
         uint8_t : 1;
+#else
+        uint8_t : 1;
+        uint8_t XMY : 1;
+        uint8_t XBGR : 1;
+        uint8_t XINV : 1;
+        uint8_t XMX : 1;
+        uint8_t XMH : 1;
+        uint8_t XMV : 1;
+        uint8_t XGS : 1;
+#endif
     } LCMCTRL;
     struct {
         uint8_t ID1;
@@ -265,33 +386,41 @@ typedef struct panel_params {
         uint8_t ID3;
     } IDSET;
     struct {
-        uint8_t CMDEN : 1;
-        uint8_t : 7;
-
+        PARAM_BYTE_LOW(CMDEN, 1);
         uint8_t PAD_FF;
     } VDVVRHEN;
     struct {
-        uint8_t VRHS : 6;
-        uint8_t : 2;
+        PARAM_BYTE_LOW(VRHS, 6);
     } VRHSET;
     struct {
-        uint8_t VDVS : 6;
-        uint8_t : 2;
+        PARAM_BYTE_LOW(VDVS, 6);
     } VDVSET;
     struct {
-        uint8_t VCMOFS : 6;
-        uint8_t : 2;
+        PARAM_BYTE_LOW(VCMOFS, 6);
     } VCMOFSET;
     struct {
+#if CEMU_BITFIELD_ORDER == CEMU_LITTLE_ENDIAN
         uint8_t RTNA : 5;
         uint8_t NLA : 3;
+#else
+        uint8_t NLA : 3;
+        uint8_t RTNA : 5;
+#endif
     } FRCTRL2;
     struct {
+#if CEMU_BITFIELD_ORDER == CEMU_LITTLE_ENDIAN
         uint8_t PWMPOL : 1;
         uint8_t PWMFIX : 1;
         uint8_t DPOFPWM : 1;
         uint8_t LEDONREV : 1;
         uint8_t : 4;
+#else
+        uint8_t : 4;
+        uint8_t LEDONREV : 1;
+        uint8_t DPOFPWM : 1;
+        uint8_t PWMFIX : 1;
+        uint8_t PWMPOL : 1;
+#endif
     } CABCCTRL;
     struct {
         uint8_t PAD_08;
@@ -300,17 +429,30 @@ typedef struct panel_params {
         uint8_t PAD_0F;
     } REGSEL2;
     struct {
+#if CEMU_BITFIELD_ORDER == CEMU_LITTLE_ENDIAN
         uint8_t CLK : 3;
         uint8_t CS : 3;
         uint8_t : 2;
+#else
+        uint8_t : 2;
+        uint8_t CS : 3;
+        uint8_t CLK : 3;
+#endif
     } PWMFRSEL;
     struct {
         uint8_t PAD_A4;
 
+#if CEMU_BITFIELD_ORDER == CEMU_LITTLE_ENDIAN
         uint8_t VDS : 2;
         uint8_t : 2;
         uint8_t AVCL : 2;
         uint8_t AVDD : 2;
+#else
+        uint8_t AVDD : 2;
+        uint8_t AVCL : 2;
+        uint8_t : 2;
+        uint8_t VDS : 2;
+#endif
     } PWCTRL1;
     struct {
         uint8_t PAD_4C;
@@ -319,45 +461,58 @@ typedef struct panel_params {
         uint8_t PAD_5A;
         uint8_t PAD_69;
         uint8_t PAD_02;
-
-        uint8_t EN : 1;
-        uint8_t : 7;
+        PARAM_BYTE_LOW(EN, 1);
     } CMD2EN;
     struct {
-        uint8_t NL : 6;
-        uint8_t : 2;
+        PARAM_BYTE_LOW(NL, 6);
+        PARAM_BYTE_LOW(SCN, 6);
 
-        uint8_t SCN : 6;
-        uint8_t : 2;
-
+#if CEMU_BITFIELD_ORDER == CEMU_LITTLE_ENDIAN
         uint8_t GS : 1;
         uint8_t SS : 1;
         uint8_t SM : 1;
         uint8_t : 1;
         uint8_t TMG : 1;
         uint8_t : 3;
+#else
+        uint8_t : 3;
+        uint8_t TMG : 1;
+        uint8_t : 1;
+        uint8_t SM : 1;
+        uint8_t SS : 1;
+        uint8_t GS : 1;
+#endif
     } GATECTRL;
     struct {
+#if CEMU_BITFIELD_ORDER == CEMU_LITTLE_ENDIAN
         uint8_t SPIRD : 1;
         uint8_t : 3;
         uint8_t SPI2EN : 1;
         uint8_t : 3;
+#else
+        uint8_t : 3;
+        uint8_t SPI2EN : 1;
+        uint8_t : 3;
+        uint8_t SPIRD : 1;
+#endif
     } SPI2EN;
     struct {
+#if CEMU_BITFIELD_ORDER == CEMU_LITTLE_ENDIAN
         uint8_t STP14CK : 2;
         uint8_t : 2;
         uint8_t SBCLK : 2;
         uint8_t : 2;
+#else
+        uint8_t : 2;
+        uint8_t SBCLK : 2;
+        uint8_t : 2;
+        uint8_t STP14CK : 2;
+#endif
     } PWCTRL2;
     struct {
-        uint8_t SEQ : 5;
-        uint8_t : 3;
-
-        uint8_t SPRET : 5;
-        uint8_t : 3;
-
-        uint8_t GEQ : 4;
-        uint8_t : 4;
+        PARAM_BYTE_LOW(SEQ, 5);
+        PARAM_BYTE_LOW(SPRET, 5);
+        PARAM_BYTE_LOW(GEQ, 4);
     } EQCTRL;
     struct {
         uint8_t PAD_01;
@@ -367,9 +522,15 @@ typedef struct panel_params {
         uint8_t PAD_69;
         uint8_t PAD_EE;
 
+#if CEMU_BITFIELD_ORDER == CEMU_LITTLE_ENDIAN
         uint8_t : 2;
         uint8_t PROMEN : 1;
         uint8_t : 5;
+#else
+        uint8_t : 5;
+        uint8_t PROMEN : 1;
+        uint8_t : 2;
+#endif
     } PROMEN;
     struct {
         uint8_t ADD;
@@ -381,19 +542,25 @@ typedef struct panel_params {
     } PROMACT;
     /* Gamma-modifying params */
     struct {
-        uint8_t GC : 4;
-        uint8_t : 4;
+        PARAM_BYTE_LOW(GC, 4);
     } GAMSET;
     struct {
+#if CEMU_BITFIELD_ORDER == CEMU_LITTLE_ENDIAN
         uint8_t : 2;
         uint8_t DGMEN : 1;
         uint8_t : 5;
+#else
+        uint8_t : 5;
+        uint8_t DGMEN : 1;
+        uint8_t : 2;
+#endif
     } DGMEN;
     panel_gamma_t PVGAMCTRL;
     panel_gamma_t NVGAMCTRL;
     uint8_t DGMLUTR[64];
     uint8_t DGMLUTB[64];
 } panel_params_t;
+#undef PARAM_BYTE_LOW
 
 typedef struct panel_state {
     uint32_t lineStartTick;

--- a/core/panel.h
+++ b/core/panel.h
@@ -11,10 +11,12 @@ extern "C" {
 #include <stdbool.h>
 #include <stdio.h>
 
-#define PANEL_RED 0
-#define PANEL_GREEN 1
-#define PANEL_BLUE 2
-#define PANEL_ALPHA 3
+#define PANEL_RAM_RED 0
+#define PANEL_RAM_GREEN 1
+#define PANEL_RAM_BLUE 2
+#define PANEL_DISP_RED 16
+#define PANEL_DISP_GREEN 8
+#define PANEL_DISP_BLUE 0
 #define PANEL_NUM_ROWS 320
 #define PANEL_LAST_ROW 319
 #define PANEL_NUM_COLS 240
@@ -576,8 +578,8 @@ typedef struct panel_state {
     uint32_t ifPixel;
 
     panel_params_t params;
-    uint8_t lineBuffers[2][240][3];
-    uint8_t frame[320][240][3], display[240][320][4];
+    uint8_t frame[PANEL_NUM_ROWS][PANEL_NUM_COLS][3];
+    uint32_t lineBuffers[2][PANEL_NUM_COLS], display[PANEL_NUM_COLS][PANEL_NUM_ROWS];
 
     /* Below state is not affected by reset */
     uint32_t clockRate;
@@ -588,8 +590,8 @@ typedef struct panel_state {
     void (*write_pixel)(panel_mem_ptr_t *memPtr, uint32_t bgr666);
     panel_mem_ptr_t windowStart, windowEnd;
     uint8_t (*windowBasePtr)[3];
+    uint32_t blankPixel;
     int8_t xDir, yDir;
-    uint8_t blankLevel;
     bool accurateGamma;
     bool gammaDirty;
     bool skipFrame;

--- a/core/timers.h
+++ b/core/timers.h
@@ -15,8 +15,13 @@ typedef struct timer_state {
 } timer_state_t;
 
 typedef struct general_timers_state {
-    timer_state_t timer[3];
-    uint32_t control, status, mask, revision;
+    union {
+        struct {
+            timer_state_t timer[3];
+            uint32_t control, status, mask, revision;
+        };
+        uint32_t regs[0x10];
+    };
     uint32_t delayStatus, delayIntrpt;
     uint8_t reset;
     bool osTimerState;

--- a/core/usb/usb.h
+++ b/core/usb/usb.h
@@ -10,7 +10,11 @@
 #include "fotg210.h"
 
 typedef struct usb_state {
-    struct fotg210_regs regs;
+    union {
+        struct fotg210_regs regs;
+        uint32_t            regWords[sizeof(struct fotg210_regs) >> 2];
+        uint8_t             regBytes[sizeof(struct fotg210_regs)];
+    };
     uint8_t ep0_data[8]; /* 0x1d0: EP0 Setup Packet PIO Register */
     uint8_t ep0_idx;
     uint8_t fifo_data[4][1024], cxfifo_data[64];

--- a/gui/qt/capture/animated-png.c
+++ b/gui/qt/capture/animated-png.c
@@ -175,9 +175,9 @@ bool apng_save(const char *filename, bool optimize) {
         for (i = 0; i != TABLE_SIZE; i++) {
             if (apng.table[i]) {
                 j = apng.table[i] >> 24;
-                palette[j].red = apng.table[i];
+                palette[j].red = apng.table[i] >> 16;
                 palette[j].green = apng.table[i] >> 8;
-                palette[j].blue = apng.table[i] >> 16;
+                palette[j].blue = apng.table[i];
             }
         }
         palette[0].red = palette[0].green = palette[0].blue = 0; /* transparent */
@@ -193,7 +193,12 @@ bool apng_save(const char *filename, bool optimize) {
     if (count <= 1 << 8) {
         png_set_packing(png_ptr);
     } else {
+#if CEMU_BYTE_ORDER == CEMU_LITTLE_ENDIAN
+        png_set_bgr(png_ptr);
         png_set_filler(png_ptr, 0, PNG_FILLER_AFTER);
+#else
+        png_set_filler(png_ptr, 0, PNG_FILLER_BEFORE);
+#endif
     }
 
     for (i = 0; i != apng.n; i++) {
@@ -206,7 +211,7 @@ bool apng_save(const char *filename, bool optimize) {
         frame.x[1] = frame.y[1] = 0;
         prev = &apng.prev[0][0];
         cur = &apng.frame[0][0];
-	if (count <= 1 << 8) {
+        if (count <= 1 << 8) {
             dst = (png_bytep)cur;
             for (y = 0; y != LCD_HEIGHT; y++) {
                 apng.row_ptrs[y] = dst;

--- a/gui/qt/debugger/visualizerdisplaywidget.cpp
+++ b/gui/qt/debugger/visualizerdisplaywidget.cpp
@@ -16,7 +16,7 @@ VisualizerDisplayWidget::VisualizerDisplayWidget(QWidget *parent) : QWidget{pare
     setContextMenuPolicy(Qt::CustomContextMenu);
     connect(this, &VisualizerDisplayWidget::customContextMenuRequested, this, &VisualizerDisplayWidget::contextMenu);
 
-    m_image = new QImage(LCD_WIDTH, LCD_HEIGHT, QImage::Format_RGBX8888);
+    m_image = new QImage(LCD_WIDTH, LCD_HEIGHT, QImage::Format_RGB32);
 }
 
 VisualizerDisplayWidget::~VisualizerDisplayWidget() {
@@ -111,7 +111,7 @@ void VisualizerDisplayWidget::setConfig(float bppstep, int w, int h, uint32_t u,
     m_size = w * h;
     m_grid = g;
     delete m_image;
-    m_image = new QImage(w, h, QImage::Format_RGBX8888);
+    m_image = new QImage(w, h, QImage::Format_RGB32);
 }
 
 void VisualizerDisplayWidget::contextMenu(const QPoint& posa) {

--- a/gui/qt/lcdwidget.cpp
+++ b/gui/qt/lcdwidget.cpp
@@ -25,8 +25,8 @@
 LCDWidget::LCDWidget(QWidget *parent) : QWidget{parent} {
     installEventFilter(keypadBridge);
     m_mutex.lock();
-    m_renderedFrame = QImage(LCD_WIDTH, LCD_HEIGHT, QImage::Format_RGBX8888);
-    m_blendedFrame = QImage(LCD_WIDTH, LCD_HEIGHT, QImage::Format_RGBX8888);
+    m_renderedFrame = QImage(LCD_WIDTH, LCD_HEIGHT, QImage::Format_RGB32);
+    m_blendedFrame = QImage(LCD_WIDTH, LCD_HEIGHT, QImage::Format_RGB32);
     m_currFrame = &m_renderedFrame;
     m_mutex.unlock();
     m_interlaceAlpha = QImage(LCD_WIDTH, LCD_HEIGHT, QImage::Format_Alpha8);
@@ -129,7 +129,7 @@ QImage LCDWidget::getImage() {
         image = m_renderedFrame.copy();
         m_mutex.unlock();
     } else {
-        image = QImage(LCD_WIDTH, LCD_HEIGHT, QImage::Format_RGBX8888);
+        image = QImage(LCD_WIDTH, LCD_HEIGHT, QImage::Format_RGB32);
         image.fill(Qt::black);
     }
     return image;
@@ -242,7 +242,7 @@ bool LCDWidget::draw() {
             QPainter c;
             if (lcd.useDma && panel.params.GATECTRL.SM) {
                 /* hack to get around format of QImage paint engine being cached forever */
-                QImage blendedFrame(m_blendedFrame.bits(), LCD_WIDTH, LCD_HEIGHT, QImage::Format_RGBA8888_Premultiplied);
+                QImage blendedFrame(m_blendedFrame.bits(), LCD_WIDTH, LCD_HEIGHT, QImage::Format_ARGB32_Premultiplied);
                 c.begin(&blendedFrame);
                 c.setCompositionMode(QPainter::CompositionMode_DestinationIn);
                 c.drawImage(QPoint(0, 0), m_interlaceAlpha);

--- a/gui/qt/romselection.cpp
+++ b/gui/qt/romselection.cpp
@@ -3,6 +3,7 @@
 #include "utils.h"
 #include "../../core/os/os.h"
 
+#include <QtCore/QtEndian>
 #include <QtCore/QFile>
 #include <QtCore/QFileInfo>
 #include <QtWidgets/QFileDialog>
@@ -149,6 +150,7 @@ void RomSelection::parseROMSegments() {
             case '1':
                 if (fseek(fd, 0x48, 0)) goto invalid;
                 if (fread(&size, sizeof(size), 1 ,fd) != 1) goto invalid;
+                size = qFromLittleEndian(size);
                 if (size != SEG_SIZE) goto invalid;
 
                 if (fread(&m_array[CERT_LOC], SEG_SIZE, 1, fd) != 1) {
@@ -160,6 +162,7 @@ void RomSelection::parseROMSegments() {
             default:
                 if (fseek(fd, 0x48, 0)) goto invalid;
                 if (fread(&size, sizeof(size), 1 ,fd) != 1) goto invalid;
+                size = qFromLittleEndian(size);
                 if (size != SEG_SIZE) goto invalid;
 
                 seg = buf[7] - 'A';

--- a/gui/sdl/main.c
+++ b/gui/sdl/main.c
@@ -93,7 +93,7 @@ void sdl_event_loop(cemu_sdl_t *cemu) {
         fprintf(stderr, "could not create renderer: %s\n", SDL_GetError());
         return;
     }
-    sdl->texture = SDL_CreateTexture(sdl->renderer, SDL_PIXELFORMAT_ABGR8888, SDL_TEXTUREACCESS_STREAMING, LCD_WIDTH, LCD_HEIGHT);
+    sdl->texture = SDL_CreateTexture(sdl->renderer, SDL_PIXELFORMAT_RGB888, SDL_TEXTUREACCESS_STREAMING, LCD_WIDTH, LCD_HEIGHT);
     if (sdl->texture == NULL) {
         fprintf(stderr, "could not create texture: %s\n", SDL_GetError());
         return;


### PR DESCRIPTION
Fixes #468, as tested on Lubuntu 16 for PowerPC in qemu. On all architectures, pixel rendering by the core has been made consistently RGB32 format (in Qt terminology).