### PR TITLE
Make keypress emulation thread-safe

### DIFF
--- a/core/atomics.h
+++ b/core/atomics.h
@@ -6,9 +6,41 @@
 #ifndef __cplusplus
 #if !defined(__STDC_NO_ATOMICS__) || (defined(_MSC_VER) && _MSC_VER >= 1935)
  #include <stdatomic.h>
+ #define atomic8_fetch_and atomic_fetch_and
+ #define atomic32_fetch_and atomic_fetch_and
+ #define atomic8_fetch_and_explicit atomic_fetch_and_explicit
+ #define atomic32_fetch_and_explicit atomic_fetch_and_explicit
+ #define atomic8_fetch_or atomic_fetch_or
+ #define atomic32_fetch_or atomic_fetch_or
+ #define atomic8_fetch_or_explicit atomic_fetch_or_explicit
+ #define atomic32_fetch_or_explicit atomic_fetch_or_explicit
 #else
  #define _Atomic(X) volatile X /* doesn't do anything, but makes me feel better... although if you are trying to do multithreading glhf */
- #define atomic_compare_exchange_strong(object, expected, desired) (*(object) == *(expected) ? (*(object) = (desired)) : (*(expected) = (desired)))
+ #define atomic_load_explicit(object, order) (*(object))
+static inline atomic8_fetch_and(volatile uint8_t *obj, uint8_t arg) {
+    uint8_t result = *obj;
+    *obj = result & arg;
+    return result;
+}
+static inline atomic32_fetch_and(volatile uint32_t *obj, uint8_t arg) {
+    uint32_t result = *obj;
+    *obj = result & arg;
+    return result;
+}
+static inline atomic8_fetch_or(volatile uint8_t *obj, uint8_t arg) {
+    uint8_t result = *obj;
+    *obj = result | arg;
+    return result;
+}
+static inline atomic32_fetch_or(volatile uint32_t *obj, uint8_t arg) {
+    uint32_t result = *obj;
+    *obj = result | arg;
+    return result;
+}
+ #define atomic8_fetch_and_explicit(object, arg, order) atomic8_fetch_and(object, arg)
+ #define atomic32_fetch_and_explicit(object, arg, order) atomic32_fetch_and(object, arg)
+ #define atomic8_fetch_or_explicit(object, arg, order) atomic8_fetch_or(object, arg)
+ #define atomic32_fetch_or_explicit(object, arg, order) atomic32_fetch_or(object, arg)
 #endif
 #else
  #include <atomic>
@@ -16,7 +48,31 @@
 #endif
 #else
  #define _Atomic(X) X
- #define atomic_compare_exchange_strong(object, expected, desired) (*(object) == *(expected) ? (*(object) = (desired)) : (*(expected) = (desired)))
+ #define atomic_load_explicit(object, order) (*(object))
+static inline atomic8_fetch_and(uint8_t *obj, uint8_t arg) {
+    uint8_t result = *obj;
+    *obj = result & arg;
+    return result;
+}
+static inline atomic32_fetch_and(uint32_t *obj, uint8_t arg) {
+    uint32_t result = *obj;
+    *obj = result & arg;
+    return result;
+}
+static inline atomic8_fetch_or(uint8_t *obj, uint8_t arg) {
+    uint8_t result = *obj;
+    *obj = result | arg;
+    return result;
+}
+static inline atomic32_fetch_or(uint32_t *obj, uint8_t arg) {
+    uint32_t result = *obj;
+    *obj = result | arg;
+    return result;
+}
+ #define atomic8_fetch_and_explicit(object, arg, order) atomic8_fetch_and(object, arg)
+ #define atomic32_fetch_and_explicit(object, arg, order) atomic32_fetch_and(object, arg)
+ #define atomic8_fetch_or_explicit(object, arg, order) atomic8_fetch_or(object, arg)
+ #define atomic32_fetch_or_explicit(object, arg, order) atomic32_fetch_or(object, arg)
 #endif
 
 #endif

--- a/core/cpu.h
+++ b/core/cpu.h
@@ -34,11 +34,13 @@ extern "C" {
 
 #define cpu_mask_mode(address, mode) ((uint32_t)((address) & ((mode) ? 0xFFFFFF : 0xFFFF)))
 
-typedef enum eZ80abort {
-    CPU_ABORT_NONE,
-    CPU_ABORT_RESET,
-    CPU_ABORT_EXIT,
-} eZ80abort_t;
+typedef enum eZ80signal {
+    CPU_SIGNAL_NONE = 0,
+    CPU_SIGNAL_EXIT = 1 << 0,
+    CPU_SIGNAL_RESET = 1 << 1,
+    CPU_SIGNAL_ON_KEY = 1 << 2,
+    CPU_SIGNAL_ANY_KEY = 1 << 3
+} eZ80signal_t;
 
 typedef union eZ80context {
     uint8_t opcode;
@@ -112,9 +114,9 @@ void cpu_flush(uint32_t, bool);
 void cpu_nmi(void);
 void cpu_execute(void);
 void cpu_restore_next(void);
-void cpu_transition_abort(uint8_t from, uint8_t to);
-uint8_t cpu_check_abort(void);
-void cpu_exit(void);
+void cpu_set_signal(uint8_t signal);
+uint8_t cpu_check_signals(void);
+uint8_t cpu_clear_signals(void);
 void cpu_crash(const char *msg);
 bool cpu_restore(FILE *image);
 bool cpu_save(FILE *image);

--- a/core/keypad.h
+++ b/core/keypad.h
@@ -12,6 +12,9 @@ extern "C" {
 #include <stdbool.h>
 #include <stdio.h>
 
+#define KEYPAD_MAX_COLS 16
+#define KEYPAD_MAX_ROWS 16
+
 typedef struct keypad_state {
     union {
         struct {
@@ -36,17 +39,15 @@ typedef struct keypad_state {
     uint8_t  row;
     uint8_t  status;
     uint8_t  enable;
-    uint16_t data[16];
-    uint16_t keyMap[16];
-    uint16_t delay[16];
-    uint32_t gpioStatus;
+    uint16_t data[KEYPAD_MAX_ROWS];
     uint32_t gpioEnable;
 } keypad_state_t;
 
 extern keypad_state_t keypad;
 
 eZ80portrange_t init_keypad(void);
-void keypad_intrpt_check(void);
+void keypad_any_check(void);
+void keypad_on_check(void);
 void keypad_reset(void);
 bool keypad_restore(FILE *image);
 bool keypad_save(FILE *image);

--- a/gui/qt/emuthread.cpp
+++ b/gui/qt/emuthread.cpp
@@ -60,7 +60,7 @@ EmuThread::EmuThread(QObject *parent) : QThread{parent}, write{CONSOLE_BUFFER_SI
 }
 
 void EmuThread::run() {
-    while (cpu_check_abort() != CPU_ABORT_EXIT) {
+    while (!(cpu_check_signals() & CPU_SIGNAL_EXIT)) {
         emu_run(1u);
         doStuff();
         throttleWait();

--- a/gui/qt/keypad/qtkeypadbridge.cpp
+++ b/gui/qt/keypad/qtkeypadbridge.cpp
@@ -83,9 +83,6 @@ void QtKeypadBridge::skEvent(QKeyEvent *event, bool press) {
             }
         }
     }
-
-    keypad.gpioEnable |= 0x800;
-    keypad_intrpt_check();
 }
 
 void QtKeypadBridge::kEvent(QString text, int key, bool repeat) {


### PR DESCRIPTION
See #486. In addition to the approach I described in that issue, I ended up splitting ON keypresses and other keypresses into different types of CPU signals since they're processed pretty differently.