### PR TITLE
Resolve ambiguous overloaded function argument

### DIFF
--- a/gui/qt/mainwindow.cpp
+++ b/gui/qt/mainwindow.cpp
@@ -1150,7 +1150,7 @@ void MainWindow::showEvent(QShowEvent *e) {
 DockWidget *MainWindow::redistributeFindDock(const QPoint &pos) {
     QWidget *child = childAt(pos);
     if (QTabBar *tabBar = findSelfOrParent<QTabBar *>(child)) {
-        child = childAt({pos.x(), tabBar->mapTo(this, QPoint{}).y() - 1});
+        child = childAt((const QPoint&){pos.x(), tabBar->mapTo(this, QPoint{}).y() - 1});
     }
     return findSelfOrParent<DockWidget *>(child);
 }

--- a/gui/qt/mainwindow.cpp
+++ b/gui/qt/mainwindow.cpp
@@ -1150,7 +1150,7 @@ void MainWindow::showEvent(QShowEvent *e) {
 DockWidget *MainWindow::redistributeFindDock(const QPoint &pos) {
     QWidget *child = childAt(pos);
     if (QTabBar *tabBar = findSelfOrParent<QTabBar *>(child)) {
-        child = childAt((const QPoint&){pos.x(), tabBar->mapTo(this, QPoint{}).y() - 1});
+        child = childAt(QPoint({pos.x(), tabBar->mapTo(this, QPoint{}).y() - 1}));
     }
     return findSelfOrParent<DockWidget *>(child);
 }


### PR DESCRIPTION
This prevents building on Nixpkgs due to Qt 6.8.0. This resolves the issue on that version, but it may or may not help with Qt 6.7.