### PR TITLE
Add support for larger Flash chips

### DIFF
--- a/core/interrupt.c
+++ b/core/interrupt.c
@@ -123,19 +123,19 @@ eZ80portrange_t init_intrpt(void) {
 }
 
 bool intrpt_save(FILE *image) {
-    bool ret = false;
+    bool ret = true;
     size_t request;
     for (request = 0; request < sizeof(intrpt) / sizeof(*intrpt); request++) {
-        ret |= fwrite(&intrpt[request], sizeof(intrpt[request]), 1, image) == 1;
+        ret &= fwrite(&intrpt[request], sizeof(intrpt[request]), 1, image) == 1;
     }
     return ret;
 }
 
 bool intrpt_restore(FILE *image) {
-    bool ret = false;
+    bool ret = true;
     size_t request;
     for (request = 0; request < sizeof(intrpt) / sizeof(*intrpt); request++) {
-        ret |= fread(&intrpt[request], sizeof(intrpt[request]), 1, image) == 1;
+        ret &= fread(&intrpt[request], sizeof(intrpt[request]), 1, image) == 1;
     }
     return ret;
 }

--- a/core/lcd.c
+++ b/core/lcd.c
@@ -592,7 +592,7 @@ void emu_set_lcd_ptrs(uint32_t **dat, uint32_t **dat_end, int width, int height,
     }
 
     if (addr < 0xD00000) {
-        mem_end = mem.flash.block + SIZE_FLASH;
+        mem_end = mem.flash.block + mem.flash.size;
         data_start = mem.flash.block + addr;
     } else if (addr < 0xE00000) {
         mem_end = mem.ram.block + SIZE_RAM;

--- a/core/mem.c
+++ b/core/mem.c
@@ -511,7 +511,8 @@ static uint8_t mem_read_flash_parallel(uint32_t addr) {
                 }
                 break;
             case FLASH_READ_CFI:
-                if (!(addr & 1) && addr >= 0x20 && addr <= 0xA0) {
+                addr &= 0xFF;
+                if (addr >= 0x20 && addr < 0xB0) {
                     /* W29GL032CB7S */
                     static const uint8_t id_4mb[] = {
                         /* Identification */
@@ -524,10 +525,14 @@ static uint8_t mem_read_flash_parallel(uint32_t addr) {
                         0x16, 0x02, 0x00, 0x05, 0x00, 0x02, 0x07, 0x00,
                         0x20, 0x00, 0x3E, 0x00, 0x00, 0x01, 0x00, 0x00,
                         0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                        /* Empty gap */
+                        0x00, 0x00, 0x00,
                         /* Vendor-Specific */
                         0x50, 0x52, 0x49, 0x31, 0x33, 0x0C, 0x02, 0x01,
                         0x00, 0x08, 0x00, 0x00, 0x02, 0x95, 0xA5, 0x02,
-                        0x01 };
+                        0x01,
+                        /* Undocumented */
+                        0x01, 0x08, 0x0F, 0x09, 0x05, 0x05, 0x00 };
                     /* W29GL064CB7S */
                     static const uint8_t id_8mb[] = {
                         /* Identification */
@@ -540,11 +545,17 @@ static uint8_t mem_read_flash_parallel(uint32_t addr) {
                         0x17, 0x02, 0x00, 0x05, 0x00, 0x02, 0x07, 0x00,
                         0x20, 0x00, 0x7E, 0x00, 0x00, 0x01, 0x00, 0x00,
                         0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                        /* Empty gap */
+                        0x00, 0x00, 0x00,
                         /* Vendor-Specific */
                         0x50, 0x52, 0x49, 0x31, 0x33, 0x0C, 0x02, 0x01,
                         0x00, 0x08, 0x00, 0x00, 0x02, 0x95, 0xA5, 0x02,
-                        0x01 };
+                        0x01,
+                        /* Undocumented (unverified) */
+                        0x01, 0x08, 0x0F, 0x09, 0x05, 0x05, 0x00 };
                     value = (mem.flash.size == SIZE_FLASH_MIN ? id_4mb : id_8mb)[(addr - 0x20) / 2];
+                } else {
+                    value = 0xFF;
                 }
                 break;
             case FLASH_DEEP_POWER_DOWN:

--- a/core/mem.h
+++ b/core/mem.h
@@ -10,10 +10,12 @@ extern "C" {
 #include <stdbool.h>
 
 #define SIZE_RAM              0x65800
-#define SIZE_FLASH            0x400000
+#define SIZE_FLASH_MIN        0x400000
+#define SIZE_FLASH_MAX_PAR    0x800000
+#define SIZE_FLASH_MAX        0x2000000
 #define SIZE_FLASH_SECTOR_8K  0x2000
 #define SIZE_FLASH_SECTOR_64K 0x10000
-#define NUM_SECTORS 64
+#define NUM_SECTORS_MAX (SIZE_FLASH_MAX_PAR / SIZE_FLASH_SECTOR_64K)
 #define NUM_8K_SECTORS 8
 
 enum flash_commands {
@@ -38,15 +40,15 @@ typedef struct {
 typedef struct {
     uint8_t dpb : 1;
     uint8_t ipb : 1;
-    uint8_t *ptr;
 } flash_sector_state_t;
 
 typedef struct {
     uint8_t write;
     uint8_t read;
-    flash_sector_state_t sector8k[8];
-    flash_sector_state_t sector[64];
+    flash_sector_state_t sector8k[NUM_8K_SECTORS];
+    flash_sector_state_t sector[NUM_SECTORS_MAX];
     uint8_t *block;
+    uint32_t size;
 
     /* internal */
     uint8_t command;

--- a/core/vat.c
+++ b/core/vat.c
@@ -318,7 +318,7 @@ bool vat_search_next(calc_var_t *var) {
     } else {
         var->namelen = 3;
     }
-    var->archived = var->address > 0xC0000 && var->address < 0x400000;
+    var->archived = var->address > 0xC0000 && var->address < 0xC00000;
     if (var->archived) {
         var->address += 9 + var->named + var->namelen;
     } else if (var->address < 0xD1A881 || var->address >= 0xD40000) {

--- a/gui/qt/debugger/hexwidget.h
+++ b/gui/qt/debugger/hexwidget.h
@@ -91,7 +91,6 @@ private:
     QByteArray m_data;
     QByteArray m_modified;
     int m_size;
-    int m_maxOffset;
 
     QRect m_cursor;
     int m_cursorOffset = 0;

--- a/gui/qt/memorywidget.cpp
+++ b/gui/qt/memorywidget.cpp
@@ -46,7 +46,7 @@ void MainWindow::flashUpdate() const {
         return;
     }
 
-    ui->flashEdit->setData({reinterpret_cast<const char *>(mem.flash.block), 0x400000});
+    ui->flashEdit->setData({reinterpret_cast<const char *>(mem.flash.block), qMin(mem.flash.size, UINT32_C(0xC00000))});
 }
 
 void MainWindow::ramUpdate() const {
@@ -248,7 +248,7 @@ void MainWindow::memSync(HexWidget *edit) {
 
 void MainWindow::flashSyncPressed() {
     if (ui->flashEdit->modifiedCount()) {
-        memcpy(mem.flash.block, ui->flashEdit->data(), 0x400000);
+        memcpy(mem.flash.block, ui->flashEdit->data(), qMin(mem.flash.size, (uint32_t)ui->flashEdit->getSize()));
     }
     memSync(ui->flashEdit);
 }

--- a/gui/qt/memorywidget.cpp
+++ b/gui/qt/memorywidget.cpp
@@ -71,7 +71,7 @@ void MainWindow::memUpdateEdit(HexWidget *edit, bool force) {
         int base = edit->getBase();
         int addr = off + base;
         int start = addr - 0x1000;
-        int end = addr + 0x1000;
+        int end = addr + 0x1000 - 1;
         off = 0x1000;
 
         if (start < 0) {
@@ -83,7 +83,7 @@ void MainWindow::memUpdateEdit(HexWidget *edit, bool force) {
         }
         data.resize(end - start + 1);
 
-        for (int j = 0, i = start; i < end; j++, i++) {
+        for (int j = 0, i = start; i <= end; j++, i++) {
             data[j] = static_cast<char>(mem_peek_byte(static_cast<uint32_t>(i)));
         }
 


### PR DESCRIPTION
To simulate the effect of modded calculators with larger Flash chips, this adds support for 8MB, 16MB, and 32MB chips, automatically selected based on the size of the ROM file.

At the moment, this is primarily useful along with [CE Patch Manager](https://github.com/qnex0/ce-patch-manager). At the moment, the patched ROM output from that tool must be manually padded with 0xFF bytes to the desired ROM size.

Note: For parallel Flash chips (pre rev M), only an 8MB chip is emulated even if the ROM is a larger size. The CFI query data has been updated to be correct for the W29GL032CB7S (4MB) and to use data from the W29GL064CB7S for 8MB.

I also need to figure out what to do about the "bootable image" file format, because that currently always contains a 4MB ROM with no header, followed by the contents of the CEmu settings file. Should I change the format to have a size prefix, or just stick with 4MB always?