### PR TITLE
Fix emscripten build for emsdk 3.x

### DIFF
--- a/core/emscripten.mk
+++ b/core/emscripten.mk
@@ -7,13 +7,15 @@ CFLAGS  = -W -Wall -O3 -flto
 CFLAGS += -DDEBUG_SUPPORT
 
 # Emscripten stuff
-EMFLAGS := -s TOTAL_MEMORY=33554432 --memory-init-file 0 -s WASM=1 -s EXPORT_ES6=1 -s MODULARIZE=1 -s EXPORT_NAME="'WebCEmu'" -s INVOKE_RUN=0 -s NO_EXIT_RUNTIME=1 -s ASSERTIONS=0 -s "EXTRA_EXPORTED_RUNTIME_METHODS=['FS', 'callMain', 'ccall', 'cwrap']"
+EMFLAGS := -s TOTAL_MEMORY=33554432 -s ALLOW_MEMORY_GROWTH=0 --memory-init-file 0 -s WASM=1 -s EXPORT_ES6=1 -s MODULARIZE=1 -s EXPORT_NAME="'WebCEmu'" -s INVOKE_RUN=0 -s NO_EXIT_RUNTIME=1 -s ASSERTIONS=0
+EMFLAGS += -s "EXPORTED_RUNTIME_METHODS=['FS', 'callMain', 'ccall', 'cwrap']"
+EMFLAGS += -s "EXPORTED_FUNCTIONS=['_main', '_malloc', '_free', '_emu_keypad_event', '_lcd_get_frame', '_emu_reset', '_emu_exit', '_emu_load', '_emu_save', '_set_file_to_send', '_emsc_set_main_loop_timing', '_emsc_pause_main_loop', '_emsc_resume_main_loop', '_emsc_cancel_main_loop', '_get_device_type', '_get_asic_revision', '_get_asic_python', '_emu_send_variable', '_sendCSC', '_sendKey', '_sendLetterKeyPress']"
 
 LFLAGS := -flto $(EMFLAGS)
 
 CSOURCES := $(wildcard *.c) $(wildcard ./usb/*.c) ./debug/debug.c ./os/os-emscripten.c
 
-OBJS = $(patsubst %.c, %.bc, $(CSOURCES))
+OBJS = $(patsubst %.c, %.o, $(CSOURCES))
 
 OUTPUT := WebCEmu
 
@@ -21,7 +23,7 @@ wasm:  $(OUTPUT).js
 
 all: wasm
 
-%.bc: %.c
+%.o: %.c
 	$(CC) $(CFLAGS) -c $< -o $@
 
 $(OUTPUT).js: $(OBJS)

--- a/core/os/os-emscripten.c
+++ b/core/os/os-emscripten.c
@@ -78,15 +78,24 @@ void gui_console_err_printf(const char *fmt, ...) {
     va_end(ap);
 }
 
+asic_rev_t gui_handle_reset(const boot_ver_t *boot_ver, asic_rev_t loaded_rev,
+                            asic_rev_t default_rev, emu_device_t device, bool *python) {
+    (void)boot_ver;
+    (void)loaded_rev;
+    (void)device;
+    (void)python;
+    return default_rev;
+}
+
 FILE *fopen_utf8(const char *filename, const char *mode) {
     return fopen(filename, mode);
 }
 
-void EMSCRIPTEN_KEEPALIVE set_file_to_send(const char* path) {
+void EMSCRIPTEN_KEEPALIVE set_file_to_send(const char *path) {
     strcpy(file_buf, path);
 }
 
-uint32_t* EMSCRIPTEN_KEEPALIVE lcd_get_frame() {
+uint32_t *EMSCRIPTEN_KEEPALIVE lcd_get_frame() {
     return &(panel.display[0][0]);
 }
 
@@ -107,7 +116,7 @@ void EMSCRIPTEN_KEEPALIVE emsc_cancel_main_loop() {
     emscripten_cancel_main_loop();
 }
 
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
     int success;
     (void)argc;
     (void)argv;
@@ -132,8 +141,8 @@ int main(int argc, char* argv[]) {
     } else {
         EM_ASM(
             emul_is_inited = false;
-            disableGUI();
-            alert("Error: Couldn't start emulation ; bad ROM?");
+            if (typeof disableGUI === 'function') disableGUI();
+            console.error("Error: Couldn't start emulation; bad ROM?");
         );
         return 1;
     }


### PR DESCRIPTION
The emscripten build target doesn't compile on emsdk 3.x. `EXTRA_EXPORTED_RUNTIME_METHODS` was renamed to `EXPORTED_RUNTIME_METHODS`, the `.bc` object extension is deprecated in favor of `.o`, and `gui_handle_reset()` is missing from `os-emscripten.c` causing an undefined symbol at link time.

This adds an explicit `EXPORTED_FUNCTIONS` list for all `EMSCRIPTEN_KEEPALIVE` symbols and fixes the above issues. Tested with emsdk 3.1.74.